### PR TITLE
Add cross-folder fallback for SimilarSearch selection and App-level openImageById handler

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -268,6 +268,39 @@ function AppContent({ isConnected }: AppContentProps) {
     }
   };
 
+  const openImageById = useCallback(async (id: number): Promise<boolean> => {
+    if (!window.electron) return false;
+
+    try {
+      const details = await window.electron.getImageDetails(id);
+      if (!details) return false;
+
+      if (details.folder_id && details.folder_id !== selectedFolderId) {
+        setSelectedFolderId(details.folder_id);
+        setIncludeSubfolders(false);
+        setActiveStackId(null);
+        setActiveStackInfo(null);
+        setStackImages([]);
+      }
+
+      const imgList = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
+      const idx = imgList.findIndex(img => img.id === id);
+
+      if (idx >= 0) {
+        setCurrentImageIndex(idx);
+        setOpeningImage(imgList[idx]);
+      } else {
+        setCurrentImageIndex(-1);
+        setOpeningImage(details as ImageRow);
+      }
+
+      return true;
+    } catch (err) {
+      console.error('Failed to open image by id:', err);
+      return false;
+    }
+  }, [selectedFolderId, stacksMode, activeStackId, stacks, stackImages, images]);
+
   const handleImageDelete = (id: number) => {
     if (activeStackId) {
       setStackImages(prev => prev.filter(img => img.id !== id));
@@ -670,6 +703,7 @@ function AppContent({ isConnected }: AppContentProps) {
                     currentIndex={currentImageIndex}
                     onNavigate={handleNavigateImage}
                     onDelete={handleImageDelete}
+                    onOpenImageById={openImageById}
                     onOpenFolder={(folderId) => {
                       setSelectedFolderId(folderId);
                       setIncludeSubfolders(false);

--- a/src/components/Viewer/ImageViewer.tsx
+++ b/src/components/Viewer/ImageViewer.tsx
@@ -43,6 +43,7 @@ interface ImageViewerProps {
     onNavigate?: (newIndex: number) => void;
     onDelete?: (id: number) => void;
     onOpenFolder?: (folderId: number) => void;
+    onOpenImageById?: (id: number) => Promise<boolean>;
 }
 
 const isWebSafe = (filename: string) => {
@@ -83,7 +84,8 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
     currentIndex = 0,
     onNavigate,
     onDelete,
-    onOpenFolder
+    onOpenFolder,
+    onOpenImageById
 }) => {
     const [image, setImage] = React.useState<Image>(initialImage);
     const [detailsLoaded, setDetailsLoaded] = React.useState(false);
@@ -106,7 +108,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
 
     // Update image when navigating
     useEffect(() => {
-        if (allImages && allImages[currentIndex]) {
+        if (currentIndex >= 0 && allImages && allImages[currentIndex]) {
             setImage(allImages[currentIndex]);
             setDetailsLoaded(false);
         }
@@ -895,13 +897,28 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                 open={isSimilarDrawerOpen}
                 onClose={() => setIsSimilarDrawerOpen(false)}
                 queryImageId={image.id}
-                onSelectImage={(id) => {
+                onSelectImage={async (id) => {
                     const idx = allImages.findIndex(img => img.id === id);
                     if (idx >= 0 && onNavigate) {
                         onNavigate(idx);
-                        // Optionally close drawer or keep it open
-                    } else {
-                        alert('Image not found in current view');
+                        setIsSimilarDrawerOpen(false);
+                        return;
+                    }
+
+                    if (onOpenImageById) {
+                        const opened = await onOpenImageById(id);
+                        if (opened) {
+                            setIsSimilarDrawerOpen(false);
+                            return;
+                        }
+                    }
+
+                    if (!window.electron) return;
+                    const details = await window.electron.getImageDetails(id);
+                    if (details) {
+                        setImage(details);
+                        setDetailsLoaded(true);
+                        setIsSimilarDrawerOpen(false);
                     }
                 }}
             />

--- a/src/components/Viewer/ImageViewer.tsx
+++ b/src/components/Viewer/ImageViewer.tsx
@@ -111,8 +111,11 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
         if (currentIndex >= 0 && allImages && allImages[currentIndex]) {
             setImage(allImages[currentIndex]);
             setDetailsLoaded(false);
+        } else if (currentIndex === -1) {
+            setImage(initialImage);
+            setDetailsLoaded(false);
         }
-    }, [currentIndex, allImages]);
+    }, [currentIndex, allImages, initialImage]);
 
     // Fetch full details
     useEffect(() => {


### PR DESCRIPTION
### Motivation
- Enable opening a similar-image result even when the target image is not present in the current gallery list, and avoid an alert fallback in the viewer.

### Description
- Added `onOpenImageById?: (id: number) => Promise<boolean>` prop to `ImageViewer` so the viewer can request app-level navigation when a similar-image is selected.
- Replaced alert fallback in `ImageViewer` `SimilarSearchDrawer` `onSelectImage` with an async flow that: first navigates if the image exists in `allImages`, then delegates to `onOpenImageById`, and finally falls back to `window.electron.getImageDetails(id)` to load the image details directly into the viewer.
- Implemented `openImageById` in `AppContent` which fetches `window.electron.getImageDetails(id)`, switches `selectedFolderId` / clears stack/subfolder state if the target image belongs to a different folder, and opens the image in the viewer (either by selecting an index in the current list or by setting the fetched image when not present).
- Wired `openImageById` down to `ImageViewer` via the `onOpenImageById` prop and added a small guard to the viewer update logic to handle `currentIndex >= 0` safely.

### Testing
- Ran `npx eslint src/AppContent.tsx src/components/Viewer/ImageViewer.tsx`; this reported only existing hook-related warnings and no new errors for the modified files (success with warnings).
- Ran `npm run lint` for the repository; this failed due to pre-existing, repo-wide lint issues unrelated to this change (e.g. `no-explicit-any` and other files), so the change itself did not introduce new lint errors in the touched files.
- Verified the changes compile locally and committed the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fbeb94b4832397cc11177a13fc16)