### PR TITLE
Support opening images by ID from viewer and similar-search; sync folder selection

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -49,6 +49,7 @@ function AppContent({ isConnected }: AppContentProps) {
   const [filters, setFilters] = useState<FilterState>({ minRating: 0, sortBy: 'score_general', order: 'DESC' });
   const [openingImage, setOpeningImage] = useState<ImageRow | null>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
+  const [pendingOpenImageId, setPendingOpenImageId] = useState<number | null>(null);
   const [currentView, setCurrentView] = useState<'gallery' | 'duplicates'>('gallery');
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -257,6 +258,7 @@ function AppContent({ isConnected }: AppContentProps) {
     const imgList = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
     const index = imgList.findIndex(img => img.id === image.id);
     setCurrentImageIndex(index >= 0 ? index : 0);
+    setPendingOpenImageId(null);
     setOpeningImage(image);
   };
 
@@ -264,9 +266,53 @@ function AppContent({ isConnected }: AppContentProps) {
     const imgList = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
     if (newIndex >= 0 && newIndex < imgList.length) {
       setCurrentImageIndex(newIndex);
+      setPendingOpenImageId(null);
       setOpeningImage(imgList[newIndex]);
     }
   };
+
+  const openImageById = useCallback(async (id: number): Promise<boolean> => {
+    if (!window.electron) return false;
+
+    try {
+      const details = await window.electron.getImageDetails(id);
+      if (!details) return false;
+
+      setOpeningImage(details as ImageRow);
+      setPendingOpenImageId(id);
+
+      if (details.folder_id && details.folder_id !== selectedFolderId) {
+        setSelectedFolderId(details.folder_id);
+        setIncludeSubfolders(false);
+        setActiveStackId(null);
+        setActiveStackInfo(null);
+        setStackImages([]);
+      }
+
+      return true;
+    } catch (err) {
+      console.error('Failed to open image by id:', err);
+      return false;
+    }
+  }, [selectedFolderId]);
+
+  useEffect(() => {
+    if (!pendingOpenImageId) return;
+
+    const imgList = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
+    const idx = imgList.findIndex(img => img.id === pendingOpenImageId);
+
+    if (idx >= 0) {
+      setCurrentImageIndex(idx);
+      setOpeningImage(imgList[idx]);
+      setPendingOpenImageId(null);
+      return;
+    }
+
+    if (!imagesLoading && !stackImagesLoading && !stacksLoading) {
+      setPendingOpenImageId(null);
+    }
+  }, [pendingOpenImageId, stacksMode, activeStackId, stacks, stackImages, images, imagesLoading, stackImagesLoading, stacksLoading]);
 
   const handleImageDelete = (id: number) => {
     if (activeStackId) {
@@ -316,6 +362,7 @@ function AppContent({ isConnected }: AppContentProps) {
   };
 
   const closeViewer = () => {
+    setPendingOpenImageId(null);
     setOpeningImage(null);
   };
 
@@ -670,6 +717,7 @@ function AppContent({ isConnected }: AppContentProps) {
                     currentIndex={currentImageIndex}
                     onNavigate={handleNavigateImage}
                     onDelete={handleImageDelete}
+                    onOpenImageById={openImageById}
                     onOpenFolder={(folderId) => {
                       setSelectedFolderId(folderId);
                       setIncludeSubfolders(false);

--- a/src/components/Viewer/ImageViewer.tsx
+++ b/src/components/Viewer/ImageViewer.tsx
@@ -43,6 +43,7 @@ interface ImageViewerProps {
     onNavigate?: (newIndex: number) => void;
     onDelete?: (id: number) => void;
     onOpenFolder?: (folderId: number) => void;
+    onOpenImageById?: (id: number) => Promise<boolean>;
 }
 
 const isWebSafe = (filename: string) => {
@@ -83,7 +84,8 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
     currentIndex = 0,
     onNavigate,
     onDelete,
-    onOpenFolder
+    onOpenFolder,
+    onOpenImageById
 }) => {
     const [image, setImage] = React.useState<Image>(initialImage);
     const [detailsLoaded, setDetailsLoaded] = React.useState(false);
@@ -106,7 +108,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
 
     // Update image when navigating
     useEffect(() => {
-        if (allImages && allImages[currentIndex]) {
+        if (currentIndex >= 0 && allImages && allImages[currentIndex]) {
             setImage(allImages[currentIndex]);
             setDetailsLoaded(false);
         }
@@ -895,13 +897,28 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                 open={isSimilarDrawerOpen}
                 onClose={() => setIsSimilarDrawerOpen(false)}
                 queryImageId={image.id}
-                onSelectImage={(id) => {
+                onSelectImage={async (id) => {
                     const idx = allImages.findIndex(img => img.id === id);
                     if (idx >= 0 && onNavigate) {
                         onNavigate(idx);
-                        // Optionally close drawer or keep it open
-                    } else {
-                        alert('Image not found in current view');
+                        setIsSimilarDrawerOpen(false);
+                        return;
+                    }
+
+                    if (onOpenImageById) {
+                        const opened = await onOpenImageById(id);
+                        if (opened) {
+                            setIsSimilarDrawerOpen(false);
+                            return;
+                        }
+                    }
+
+                    if (!window.electron) return;
+                    const details = await window.electron.getImageDetails(id);
+                    if (details) {
+                        setImage(details);
+                        setDetailsLoaded(true);
+                        setIsSimilarDrawerOpen(false);
                     }
                 }}
             />


### PR DESCRIPTION
### Motivation

- Allow the viewer and the Similar Search flow to open images that are not loaded in the current grid by requesting details by ID and switching folders when necessary.

### Description

- Add `openImageById` to `AppContent` which fetches image details via `window.electron.getImageDetails`, sets `pendingOpenImageId`, and switches `selectedFolderId` when the image belongs to a different folder.
- Introduce `pendingOpenImageId` state and an effect that reconciles it once the relevant images/stacks are loaded to set `currentImageIndex` and `openingImage` automatically, and clear the pending state when appropriate.
- Wire a new `onOpenImageById` prop through `ImageViewer` and update the Similar Search selection handler to first try in-view navigation, then call `onOpenImageById`, and finally fall back to fetching details directly when needed; also adjust navigation and drawer closing behavior.
- Add small safety and UI-state fixes: reset `pendingOpenImageId` on manual opens/close/navigation, enforce index checks when updating the visible image, and add logging around details fetches.

### Testing

- Ran a TypeScript build (`yarn build`) to validate typings and compilation, which completed successfully.
- Ran the frontend unit tests (`yarn test`) and the test suite passed without failures.
- Manually exercised the viewer open-by-id and Similar Search flows in the dev environment to confirm navigation and folder switching behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fbeb94b4832397cc11177a13fc16)