### PR TITLE
Add Find Similar context menu and Jump-to-Folder integration for similar results

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -49,6 +49,8 @@ function AppContent({ isConnected }: AppContentProps) {
   const [filters, setFilters] = useState<FilterState>({ minRating: 0, sortBy: 'score_general', order: 'DESC' });
   const [openingImage, setOpeningImage] = useState<ImageRow | null>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
+  const [initialSimilarSearchImageId, setInitialSimilarSearchImageId] = useState<number | null>(null);
+  const [pendingJumpImageId, setPendingJumpImageId] = useState<number | null>(null);
   const [currentView, setCurrentView] = useState<'gallery' | 'duplicates'>('gallery');
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -254,6 +256,7 @@ function AppContent({ isConnected }: AppContentProps) {
   }, [stacksMode, cacheBuilt, refreshStacks]);
 
   const handleImageClick = (image: ImageRow) => {
+    setInitialSimilarSearchImageId(null);
     const imgList = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
     const index = imgList.findIndex(img => img.id === image.id);
     setCurrentImageIndex(index >= 0 ? index : 0);
@@ -315,13 +318,72 @@ function AppContent({ isConnected }: AppContentProps) {
     setSelectedFolderId(parentId);
   };
 
+  const openFolderAndImage = useCallback(async (imageId: number) => {
+    if (!window.electron) return;
+
+    try {
+      const details = await window.electron.getImageDetails(imageId);
+      if (!details?.folder_id) {
+        addNotification('Unable to locate folder for selected image', 'warning');
+        return;
+      }
+
+      setSelectedFolderId(details.folder_id);
+      setIncludeSubfolders(false);
+      setActiveStackId(null);
+      setActiveStackInfo(null);
+      setStackImages([]);
+      setInitialSimilarSearchImageId(null);
+      setPendingJumpImageId(imageId);
+
+      setOpeningImage({
+        id: details.id,
+        file_path: details.file_path,
+        file_name: details.file_name,
+        score_general: details.score_general,
+        score_technical: details.score_technical,
+        score_aesthetic: details.score_aesthetic,
+        score_spaq: details.score_spaq,
+        score_ava: details.score_ava,
+        score_liqe: details.score_liqe,
+        rating: details.rating,
+        label: details.label,
+        created_at: details.created_at,
+        thumbnail_path: details.thumbnail_path,
+        stack_id: details.stack_id,
+      });
+      setCurrentImageIndex(0);
+    } catch (err) {
+      console.error('Failed to jump to image folder', err);
+      addNotification('Failed to jump to image folder', 'error');
+    }
+  }, [addNotification]);
+
+  const handleFindSimilarFromGrid = (image: ImageRow) => {
+    handleImageClick(image);
+    setInitialSimilarSearchImageId(image.id);
+  };
+
   const closeViewer = () => {
     setOpeningImage(null);
+    setInitialSimilarSearchImageId(null);
+    setPendingJumpImageId(null);
   };
 
   // Determine current display
   const currentImages = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
   const currentTotal = stacksMode && !activeStackId ? stacksTotalCount : (activeStackId ? (activeStackInfo?.imageCount || stackImages.length) : totalCount);
+
+  useEffect(() => {
+    if (!pendingJumpImageId || currentImages.length === 0) return;
+
+    const idx = currentImages.findIndex(img => img.id === pendingJumpImageId);
+    if (idx < 0) return;
+
+    setCurrentImageIndex(idx);
+    setOpeningImage(currentImages[idx]);
+    setPendingJumpImageId(null);
+  }, [currentImages, pendingJumpImageId]);
 
   // Header title
   const headerTitle = (() => {
@@ -661,6 +723,7 @@ function AppContent({ isConnected }: AppContentProps) {
                   onSelectStack={handleSelectStack}
                   onStackEndReached={loadMoreStacks}
                   activeStackId={activeStackId}
+                  onFindSimilarImages={handleFindSimilarFromGrid}
                 />
                 {openingImage && (
                   <ImageViewer
@@ -670,6 +733,8 @@ function AppContent({ isConnected }: AppContentProps) {
                     currentIndex={currentImageIndex}
                     onNavigate={handleNavigateImage}
                     onDelete={handleImageDelete}
+                    initialSimilarSearchImageId={initialSimilarSearchImageId}
+                    onJumpToImageFolder={openFolderAndImage}
                     onOpenFolder={(folderId) => {
                       setSelectedFolderId(folderId);
                       setIncludeSubfolders(false);

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -94,7 +94,7 @@ function AppContent({ isConnected }: AppContentProps) {
       if (cleanupImport) cleanupImport();
       if (cleanupNotification) cleanupNotification();
     };
-  }, []);
+  }, [addNotification]);
 
   // Subfolders toggle
   const [includeSubfolders, setIncludeSubfolders] = useState(false);

--- a/src/components/Gallery/GalleryGrid.tsx
+++ b/src/components/Gallery/GalleryGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { useMemo, useCallback, useRef, useEffect, useState } from 'react';
 import { VirtuosoGrid } from 'react-virtuoso';
 import { Logger } from '../../services/Logger';
 
@@ -44,6 +44,7 @@ interface GalleryGridProps {
     onSelectStack?: (stack: Image) => void;
     onStackEndReached?: () => void;
     activeStackId?: number | null;
+    onFindSimilarImages?: (image: Image) => void;
 }
 
 const ItemContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ style, children, ...props }, ref) => (
@@ -85,21 +86,22 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
     images, onSelect, onEndReached, subfolders, onSelectFolder,
     onNavigateToParent, viewerOpen = false, sortBy = 'score_general',
     stacksMode = false, stacks = [], onSelectStack, onStackEndReached,
-    activeStackId
+    activeStackId, onFindSimilarImages
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
+    const [contextMenu, setContextMenu] = useState<{ x: number; y: number; image: Image } | null>(null);
 
     // Escape key handler for parent navigation (only when viewer is closed)
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Only handle Escape if viewer is NOT open
-            if (e.key === 'Escape' && onNavigateToParent && !viewerOpen) {
+            if (e.key === 'Escape' && onNavigateToParent && !viewerOpen && !contextMenu) {
                 onNavigateToParent();
             }
         };
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [onNavigateToParent, viewerOpen]);
+    }, [onNavigateToParent, viewerOpen, contextMenu]);
 
     useEffect(() => {
         const el = containerRef.current;
@@ -112,6 +114,23 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
             containerHeight: el.clientHeight
         });
     }, [images.length, images]);
+
+    useEffect(() => {
+        const closeMenu = () => setContextMenu(null);
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setContextMenu(null);
+        };
+
+        window.addEventListener('click', closeMenu);
+        window.addEventListener('scroll', closeMenu, true);
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('click', closeMenu);
+            window.removeEventListener('scroll', closeMenu, true);
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []);
 
     const gridComponents = useMemo(() => ({
         List: ItemContainer,
@@ -156,7 +175,16 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
         const labelColor = getLabelColor(img.label);
 
         return (
-            <div onClick={onClick} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+            <div
+                onClick={onClick}
+                onContextMenu={(e) => {
+                    e.preventDefault();
+                    if (onFindSimilarImages) {
+                        setContextMenu({ x: e.clientX, y: e.clientY, image: img });
+                    }
+                }}
+                style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+            >
                 <div style={{ flex: 1, backgroundColor: '#000', position: 'relative', overflow: 'hidden' }}>
                     {src ? (
                         <img
@@ -185,7 +213,7 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                 </div>
             </div>
         );
-    }, [getScoreDisplay, getLabelColor]);
+    }, [getScoreDisplay, getLabelColor, onFindSimilarImages]);
 
     const renderStackCard = useCallback((stack: Image, onClick: () => void) => {
         const rawPath = stack.thumbnail_path || stack.file_path;
@@ -351,6 +379,45 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                 components={gridComponents}
                 itemContent={itemContent}
             />
+
+            {contextMenu && onFindSimilarImages && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        top: contextMenu.y,
+                        left: contextMenu.x,
+                        zIndex: 2000,
+                        minWidth: 220,
+                        background: '#252526',
+                        border: '1px solid #3b3b3b',
+                        borderRadius: 6,
+                        boxShadow: '0 10px 24px rgba(0,0,0,0.45)',
+                        padding: 4
+                    }}
+                    onClick={(e) => e.stopPropagation()}
+                >
+                    <button
+                        onClick={() => {
+                            onFindSimilarImages(contextMenu.image);
+                            setContextMenu(null);
+                        }}
+                        style={{
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '8px 10px',
+                            border: 'none',
+                            background: 'transparent',
+                            color: '#e6e6e6',
+                            borderRadius: 4,
+                            cursor: 'pointer'
+                        }}
+                        onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = '#3a3d41'; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
+                    >
+                        Find Similar Images…
+                    </button>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/Viewer/ImageViewer.tsx
+++ b/src/components/Viewer/ImageViewer.tsx
@@ -43,6 +43,8 @@ interface ImageViewerProps {
     onNavigate?: (newIndex: number) => void;
     onDelete?: (id: number) => void;
     onOpenFolder?: (folderId: number) => void;
+    onJumpToImageFolder?: (imageId: number) => void;
+    initialSimilarSearchImageId?: number | null;
 }
 
 const isWebSafe = (filename: string) => {
@@ -83,7 +85,9 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
     currentIndex = 0,
     onNavigate,
     onDelete,
-    onOpenFolder
+    onOpenFolder,
+    onJumpToImageFolder,
+    initialSimilarSearchImageId
 }) => {
     const [image, setImage] = React.useState<Image>(initialImage);
     const [detailsLoaded, setDetailsLoaded] = React.useState(false);
@@ -191,7 +195,8 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
 
     // Editing & Drawer State
     const [isEditing, setIsEditing] = useState(false);
-    const [isSimilarDrawerOpen, setIsSimilarDrawerOpen] = useState(false);
+    const [isSimilarDrawerOpen, setIsSimilarDrawerOpen] = useState(!!initialSimilarSearchImageId);
+    const [similarSearchImageId, setSimilarSearchImageId] = useState<number | null>(initialSimilarSearchImageId ?? null);
     const [editForm, setEditForm] = useState({
         title: '',
         description: '',
@@ -199,6 +204,14 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
         label: '',
         keywords: ''
     });
+
+
+    useEffect(() => {
+        if (initialSimilarSearchImageId) {
+            setSimilarSearchImageId(initialSimilarSearchImageId);
+            setIsSimilarDrawerOpen(true);
+        }
+    }, [initialSimilarSearchImageId]);
 
     useEffect(() => {
         if (isEditing) {
@@ -865,7 +878,10 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                             )}
 
                             <button
-                                onClick={() => setIsSimilarDrawerOpen(true)}
+                                onClick={() => {
+                                    setSimilarSearchImageId(image.id);
+                                    setIsSimilarDrawerOpen(true);
+                                }}
                                 style={{
                                     width: '100%',
                                     padding: '8px',
@@ -894,7 +910,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
             <SimilarSearchDrawer
                 open={isSimilarDrawerOpen}
                 onClose={() => setIsSimilarDrawerOpen(false)}
-                queryImageId={image.id}
+                queryImageId={similarSearchImageId ?? image.id}
                 onSelectImage={(id) => {
                     const idx = allImages.findIndex(img => img.id === id);
                     if (idx >= 0 && onNavigate) {
@@ -904,6 +920,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                         alert('Image not found in current view');
                     }
                 }}
+                onJumpToImageFolder={(id) => onJumpToImageFolder?.(id)}
             />
         </div>
     );

--- a/src/components/Viewer/ImageViewer.tsx
+++ b/src/components/Viewer/ImageViewer.tsx
@@ -340,39 +340,39 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
 
     const src = previewSrc;
 
-    const buildExportPayload = async () => {
-        if (!src) {
-            return { error: 'No preview loaded yet.' };
-        }
-
-        try {
-            const response = await fetch(src);
-            const blob = await response.blob();
-            const buffer = await blob.arrayBuffer();
-            const bytes = Array.from(new Uint8Array(buffer));
-            const mimeType = blob.type || 'image/jpeg';
-
-            const baseName = image.file_name.replace(/\.[^/.]+$/, '');
-            const suggestedFileName = mimeType.includes('jpeg') || mimeType.includes('jpg')
-                ? `${baseName}.jpg`
-                : image.file_name;
-
-            return {
-                bytes,
-                mimeType,
-                suggestedFileName,
-                id: image.id,
-                sourcePath: image.win_path || image.file_path,
-                imageUuid: image.image_uuid || null
-            };
-        } catch (e) {
-            console.error('Failed to read displayed preview bytes:', e);
-            return { error: 'Could not read displayed preview bytes.' };
-        }
-    };
-
     useEffect(() => {
         let active = true;
+
+        const buildExportPayload = async () => {
+            if (!src) {
+                return { error: 'No preview loaded yet.' };
+            }
+
+            try {
+                const response = await fetch(src);
+                const blob = await response.blob();
+                const buffer = await blob.arrayBuffer();
+                const bytes = Array.from(new Uint8Array(buffer));
+                const mimeType = blob.type || 'image/jpeg';
+
+                const baseName = image.file_name.replace(/\.[^/.]+$/, '');
+                const suggestedFileName = mimeType.includes('jpeg') || mimeType.includes('jpg')
+                    ? `${baseName}.jpg`
+                    : image.file_name;
+
+                return {
+                    bytes,
+                    mimeType,
+                    suggestedFileName,
+                    id: image.id,
+                    sourcePath: image.win_path || image.file_path,
+                    imageUuid: image.image_uuid || null
+                };
+            } catch (e) {
+                console.error('Failed to read displayed preview bytes:', e);
+                return { error: 'Could not read displayed preview bytes.' };
+            }
+        };
 
         const syncExportContext = async () => {
             if (!window.electron) return;
@@ -408,7 +408,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                 void window.electron.setCurrentExportImageContext(null);
             }
         };
-    }, [src, image.file_name]);
+    }, [src, image.file_name, image.file_path, image.id, image.image_uuid, image.win_path]);
 
     // Format date
     const dateStr = image.created_at ? new Date(image.created_at).toLocaleString() : 'Unknown';

--- a/src/components/Viewer/SimilarSearchDrawer.tsx
+++ b/src/components/Viewer/SimilarSearchDrawer.tsx
@@ -6,9 +6,10 @@ interface SimilarSearchDrawerProps {
     queryImageId: number | null;
     currentFolderId?: number; // Optional: to restrict search to the current folder
     onSelectImage: (imageId: number) => void;
+    onJumpToImageFolder: (imageId: number) => void;
 }
 
-export function SimilarSearchDrawer({ open, onClose, queryImageId, onSelectImage }: SimilarSearchDrawerProps) {
+export function SimilarSearchDrawer({ open, onClose, queryImageId, onSelectImage, onJumpToImageFolder }: SimilarSearchDrawerProps) {
     // Only pass imageId when open to avoid unnecessary fetching in the background
     const activeImageId = open ? queryImageId : null;
     const { images, loading, error } = useSimilarImages(activeImageId, 20); // Defaulting to 20 for UI drawer
@@ -123,9 +124,30 @@ export function SimilarSearchDrawer({ open, onClose, queryImageId, onSelectImage
                                     fontSize: '0.75em',
                                     color: '#eee',
                                     display: 'flex',
-                                    justifyContent: 'flex-end'
+                                    justifyContent: 'space-between',
+                                    alignItems: 'center',
+                                    gap: 8
                                 }}>
-                                    {(img.similarity * 100).toFixed(1)}%
+                                    <button
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            e.stopPropagation();
+                                            onJumpToImageFolder(img.image_id);
+                                        }}
+                                        style={{
+                                            border: '1px solid rgba(255,255,255,0.35)',
+                                            background: 'rgba(0,0,0,0.45)',
+                                            color: '#fff',
+                                            borderRadius: 4,
+                                            fontSize: '0.75em',
+                                            padding: '2px 6px',
+                                            cursor: 'pointer'
+                                        }}
+                                        title="Open this image in its folder"
+                                    >
+                                        Jump to Folder
+                                    </button>
+                                    <span>{(img.similarity * 100).toFixed(1)}%</span>
                                 </div>
                             </div>
                         ))}


### PR DESCRIPTION
### Motivation

- Provide a quicker workflow to run a "Find Similar" search from the gallery grid and allow navigating from similar-search results into the image's containing folder.
- Ensure the viewer can be opened with an active similar-search and support jumping the main view to an arbitrary image's folder.

### Description

- Added a right-click context menu to `GalleryGrid` that exposes a `Find Similar Images…` action and manages menu lifecycle and escape/scroll handling, introduced `onFindSimilarImages` prop. 
- Extended `ImageViewer` to accept `initialSimilarSearchImageId` and `onJumpToImageFolder`, allow auto-opening the similar-search drawer, and pass the selected query id into `SimilarSearchDrawer`.
- Added a `Jump to Folder` button into `SimilarSearchDrawer` that calls back with the image id when clicked.
- Wired new interactions in `AppContent` including `handleFindSimilarFromGrid`, `openFolderAndImage` to resolve an image's folder and open it (using `window.electron.getImageDetails`), and logic to handle pending jumps and initial similar-search state.

### Testing

- Ran the application build with `yarn build` and the build completed successfully.
- Executed the frontend test suite with `yarn test` and all existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fbeceb088323a8a5e093aeb85353)