### PR TITLE
Fix preserve-items pagination refresh behavior

### DIFF
--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -299,20 +299,43 @@ function usePaginatedData<T extends { id: number }>(
         requestIdRef.current += 1;
 
         if (preserveItems && window.electron && itemsRef.current.length > 0) {
-            const nextLimit = Math.min(Math.max(itemsRef.current.length, pageSize), MAX_LOADED_ITEMS);
             const requestId = requestIdRef.current;
             const queryVersionAtStart = queryVersionRef.current;
 
             loadingRef.current = true;
             setLoading(true);
 
-            const listOptions: ImageQueryOptions = {
-                limit: nextLimit,
-                offset: 0,
+            const countOptions: ImageQueryOptions = {
                 folderId: folderIdRef.current,
                 ...filtersRef.current,
             };
-            const countOptions: ImageQueryOptions = {
+            const hasTrimmedItems = offsetRef.current > itemsRef.current.length;
+
+            if (hasTrimmedItems) {
+                void countFunc(countOptions).then(freshCount => {
+                    if (queryVersionAtStart !== queryVersionRef.current || requestId !== requestIdRef.current) {
+                        return;
+                    }
+
+                    const hasMoreItems = freshCount > offsetRef.current;
+                    hasMoreRef.current = hasMoreItems;
+                    setTotalCount(freshCount);
+                    setHasMore(hasMoreItems);
+                }).catch(err => {
+                    console.error('Failed to refresh data count:', err);
+                }).finally(() => {
+                    if (requestId === requestIdRef.current) {
+                        loadingRef.current = false;
+                        setLoading(false);
+                    }
+                });
+                return;
+            }
+
+            const nextLimit = Math.min(Math.max(itemsRef.current.length, pageSize), MAX_LOADED_ITEMS);
+            const listOptions: ImageQueryOptions = {
+                limit: nextLimit,
+                offset: 0,
                 folderId: folderIdRef.current,
                 ...filtersRef.current,
             };


### PR DESCRIPTION
## Summary
- preserve the currently visible window during refreshes instead of reloading from offset 0 after trimming
- refresh count and has-more state without corrupting pagination when the client has already trimmed older items
- keep the preserve-items path aligned with the code review finding around gallery refresh behavior

## Validation
- npx tsc -p electron/tsconfig.json --noEmit
- npm run test:run
- npx eslint electron/preload.ts src/electron.d.ts src/hooks/useDatabase.ts src/AppContent.tsx src/components/Viewer/ImageViewer.tsx src/services/Logger.test.ts src/services/WebSocketService.test.ts