### PR TITLE
Normalize TODO status across roadmap, integration, and embeddings docs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 Project-level task list. Items marked `[Python]`, `[Gradio]`, or `[DB]` involve the Python image-scoring project or database integrations.
 
+> **Source of truth & update order:** This file is the canonical task ledger (owner: Electron maintainers). Update this file first, then sync `docs/planning/01-roadmap-todo.md`, then `docs/integration/TODO.md`, and finally `docs/features/planned/embeddings/TODO.md`.
+
 Last evaluated: 2026-03-14.
 
 | Marker | Use when |
@@ -80,6 +82,7 @@ Last evaluated: 2026-03-14.
 - [ ] [Python] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
 - [ ] [Python] Sync `electron/apiTypes.ts` when backend API contract changes
 - [ ] Document `config.api.url` / `config.api.port` override in user-facing docs
+- [x] [Python] Ensure `image_updated` and `folder_updated` handlers refresh correct views
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the **Electron Image Scoring** documentation. This index provides a structured overview of the project's architecture, features, and planning.
 
+Roadmap/TODO status should be reconciled at least once per week and immediately after any task is marked complete or reopened.
+
 ---
 
 ## Architecture

--- a/docs/features/planned/embeddings/TODO.md
+++ b/docs/features/planned/embeddings/TODO.md
@@ -2,13 +2,15 @@
 
 This document tracks the remaining work for the embedding-based features in the Electron Gallery.
 
+> **Source of truth & update order:** Embeddings feature-detail mirror (owner: feature maintainers). Update only after `TODO.md` and `docs/planning/01-roadmap-todo.md`; use `docs/integration/TODO.md` to confirm backend milestone status before changing Gradio/API states.
+
 ## 🟢 Implemented
 - [x] **Diversity-Aware Selection**: Settings and MMR logic integrated.
 - [x] **Near-Duplicate Detection**: Duplicate finder view and IPC bridge.
 - [x] **"More Like This" Search**: Similarity search drawer and context menu.
 
 ## 🟡 In Progress
-- [ ] **Gradio Integration**: Enhancing the IPC/WebSocket bridge for real-time AI updates.
+- [ ] **Gradio Integration**: Enhance IPC/WebSocket bridge for real-time AI updates (job progress subscription still pending).
 
 ## 🔴 Planned (Missing)
 ### Feature 3: Tag Propagation

--- a/docs/integration/TODO.md
+++ b/docs/integration/TODO.md
@@ -2,6 +2,8 @@
 
 Tasks for Electron ↔ Python backend integration. See [Agent Coordination](https://github.com/synthet/image-scoring/blob/main/docs/technical/AGENT_COORDINATION.md) for protocols.
 
+> **Source of truth & update order:** Integration status mirror (owner: integration maintainers). Reconcile after `TODO.md` and `docs/planning/01-roadmap-todo.md`; if embedding milestones change, then sync `docs/features/planned/embeddings/TODO.md`.
+
 ## REST API
 
 - [ ] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
@@ -10,7 +12,7 @@ Tasks for Electron ↔ Python backend integration. See [Agent Coordination](http
 ## WebSocket
 
 - [ ] Subscribe to `job_progress` for live progress bar (optional; currently job_started/job_completed only)
-- [ ] Ensure `image_updated` and `folder_updated` handlers refresh correct views (implemented)
+- [x] Ensure `image_updated` and `folder_updated` handlers refresh correct views
 
 ## Configuration
 

--- a/docs/planning/01-roadmap-todo.md
+++ b/docs/planning/01-roadmap-todo.md
@@ -1,6 +1,8 @@
 # TODO - Electron Image Scoring
 
-Consolidated list of unfinished work items. Last Updated: Mar 10, 2026.
+Consolidated list of unfinished work items. Last Updated: Mar 14, 2026.
+
+> **Source of truth & update order:** Secondary roadmap mirror (owner: planning/docs maintainers). Sync only after `TODO.md`, then reconcile this file before updating `docs/integration/TODO.md` and `docs/features/planned/embeddings/TODO.md`.
 
 ---
 
@@ -18,11 +20,12 @@ Consolidated list of unfinished work items. Last Updated: Mar 10, 2026.
 
 ## P1 (High Priority)
 
-- [ ] **Embedding Feature Integration**:
+- [ ] **Embedding Feature Integration** [Python]:
     - [ ] Add "Find Similar" to context menu and details panel
     - [ ] Integrate "Duplicate Finder" into main navigation
 - [ ] Add explicit request token / in-flight guard to `useImages` for pagination races
-- [ ] Setup `Vitest` and basic test coverage for hooks/services
+- [x] Setup `Vitest` and basic test coverage for hooks/services
+- [x] Ensure `image_updated` and `folder_updated` handlers refresh correct views
 
 ## P2 (Medium Priority)
 
@@ -37,3 +40,4 @@ Consolidated list of unfinished work items. Last Updated: Mar 10, 2026.
 - [ ] Cleanup remaining lint/type warnings (`no-explicit-any`)
 - [ ] 2D Embedding Map (WebGL visualization)
 - [ ] Outlier Detection UI
+- [ ] Smart Stack Representative

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -6,3 +6,6 @@ Roadmap, migration plans, and task tracking.
 - [02 - Firebird to PostgreSQL Migration](02-firebird-postgresql-migration.md) - Coordinated platform migration plan
 
 [← Back to Documentation Index](../README.md)
+
+
+Roadmap status in this folder should be reconciled weekly and after any major completion-status change in the root `TODO.md`.


### PR DESCRIPTION
### Motivation
- Keep multiple TODO trackers synchronized so teams have a clear authoritative update flow and avoid drift between roadmap/planning/integration/feature docs. 
- Make ownership and update order explicit to reduce ambiguity when reconciling cross-repo or cross-team items. 
- Normalize overlapping item states (Vitest, embedding milestones, integration refresh handlers) so the same status appears in all mirrors.

### Description
- Added a `Source of truth & update order` note to `TODO.md`, `docs/planning/01-roadmap-todo.md`, `docs/integration/TODO.md`, and `docs/features/planned/embeddings/TODO.md` that documents ownership and the recommended reconciliation sequence. 
- Marked `Vitest` setup as completed in the planning roadmap and marked the `image_updated`/`folder_updated` refresh milestone as completed in integration and mirrored it in root/planning TODOs. 
- Clarified the Gradio/embedding wording to note the pending `job_progress` subscription and added the missing `Smart Stack Representative` planned item to the planning roadmap so embedding docs align. 
- Added cadence guidance to `docs/README.md` and `docs/planning/README.md` recommending weekly reconciliation and immediate updates after completion-status changes.

### Testing
- Ran `git diff --check` to validate patch formatting and it returned clean results. 
- Verified the working tree was clean after committing changes via `git status --short`, indicating the edits were successfully staged and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5932140d483238262d16cc79bf6fd)