### PR TITLE
docs: add auditable tracked tasks for highest-impact TODO items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,11 +23,11 @@ Last evaluated: 2026-03-14.
 
 ### Highest-Impact Next Steps (Recommended Sequence)
 
-1. **Harden data-loading race safety in `useImages`** (request token / in-flight guard) to reduce duplicate pagination fetches and stale UI updates.
-2. **Stabilize runtime observability** (log rotation/retention + bounded WebSocket reconnect policy) to keep long-running sessions predictable.
-3. **Decompose `AppContent.tsx` and align styling strategy** to lower feature-delivery friction before adding more embedding UI surfaces.
-4. **Close remaining local quality debt** (`no-explicit-any`, `useImages`/`useStacks` closure and dependency issues) so future backend integrations are lower-risk.
-5. **Execute embedding feature wave with backend coordination** (Tag Propagation → Outlier Detection → 2D Map → Smart Stack Representative).
+1. **[EIS-101](docs/planning/03-high-impact-tracked-tasks.md#eis-101---harden-useimages-data-loading-race-safety) - Harden data-loading race safety in `useImages`** (request token / in-flight guard) to reduce duplicate pagination fetches and stale UI updates.
+2. **[EIS-102](docs/planning/03-high-impact-tracked-tasks.md#eis-102---stabilize-runtime-observability) - Stabilize runtime observability** (log rotation/retention + bounded WebSocket reconnect policy) to keep long-running sessions predictable.
+3. **[EIS-103](docs/planning/03-high-impact-tracked-tasks.md#eis-103---decompose-appcontenttsx--styling-strategy-alignment) - Decompose `AppContent.tsx` and align styling strategy** to lower feature-delivery friction before adding more embedding UI surfaces.
+4. **[EIS-104](docs/planning/03-high-impact-tracked-tasks.md#eis-104---close-local-quality-debt-prior-to-backend-expansion) - Close remaining local quality debt** (`no-explicit-any`, `useImages`/`useStacks` closure and dependency issues) so future backend integrations are lower-risk.
+5. **[EIS-105](docs/planning/03-high-impact-tracked-tasks.md#eis-105---execute-embedding-feature-wave-with-backend-coordination) - Execute embedding feature wave with backend coordination** (Tag Propagation → Outlier Detection → 2D Map → Smart Stack Representative).
 
 ### Dependency Notes
 
@@ -107,3 +107,4 @@ Last evaluated: 2026-03-14.
 - [API Integration TODO](docs/integration/TODO.md)
 - [Embedding Features TODO](docs/features/planned/embeddings/TODO.md)
 - [Code Design Review](docs/reports/01-code-design-review-2026-03.md)
+- [High-Impact Tracked Tasks](docs/planning/03-high-impact-tracked-tasks.md)

--- a/docs/planning/03-high-impact-tracked-tasks.md
+++ b/docs/planning/03-high-impact-tracked-tasks.md
@@ -1,0 +1,111 @@
+# High-Impact Next Steps - Tracked Tasks
+
+Source: `TODO.md` → **Highest-Impact Next Steps (Recommended Sequence)**.
+
+These tracked tasks are the auditable execution records for the five highest-impact items and include explicit boundaries, cross-repo dependencies, definition of done, and ownership suggestions.
+
+## EIS-101 - Harden `useImages` data-loading race safety
+
+- **Source item**: "Harden data-loading race safety in `useImages` (request token / in-flight guard)"
+- **Suggested owner/team**: Electron Frontend (Gallery/Hooks)
+- **Scope boundaries**:
+  - In scope:
+    - Add request token or generation guard in `useImages` pagination flow.
+    - Add in-flight dedupe guard to prevent duplicate concurrent fetches.
+    - Ensure stale responses cannot overwrite fresher state.
+    - Add focused unit/integration coverage for race scenarios.
+  - Out of scope:
+    - Re-architecting all data hooks.
+    - Backend API contract changes.
+- **Dependencies (backend/migration)**:
+  - Backend: None required (client-side correctness hardening).
+  - Migration: None.
+- **Definition of done**:
+  - Reproduction scenario for duplicate pagination/stale overwrite is no longer reproducible.
+  - Existing hook behavior remains unchanged for normal load path.
+  - Tests cover at least one stale-response and one concurrent-request scenario.
+  - TODO references updated with completion status.
+
+## EIS-102 - Stabilize runtime observability
+
+- **Source item**: "Stabilize runtime observability (log rotation/retention + bounded WebSocket reconnect policy)"
+- **Suggested owner/team**: Electron Platform + Runtime
+- **Scope boundaries**:
+  - In scope:
+    - Add log rotation/retention policy for session logs.
+    - Implement bounded reconnect strategy (max retries + backoff + jitter) for WebSocket clients.
+    - Add runtime configuration knobs (reasonable defaults).
+  - Out of scope:
+    - End-to-end telemetry pipeline or external log aggregation.
+    - Replacing current transport protocol.
+- **Dependencies (backend/migration)**:
+  - Backend: Optional coordination if reconnect semantics need backend-side rate limiting hints.
+  - Migration: None.
+- **Definition of done**:
+  - Long-running session log growth is bounded by policy.
+  - WebSocket reconnect attempts are bounded and observable in logs.
+  - Manual failure test demonstrates backoff/jitter and clean terminal state after max retries.
+  - TODO references updated with completion status.
+
+## EIS-103 - Decompose `AppContent.tsx` + styling strategy alignment
+
+- **Source item**: "Decompose `AppContent.tsx` and align styling strategy"
+- **Suggested owner/team**: Electron Frontend Architecture
+- **Scope boundaries**:
+  - In scope:
+    - Split `AppContent.tsx` into domain-focused components/hooks with clear ownership boundaries.
+    - Document and adopt a single styling direction for net-new/modified surfaces (e.g., CSS Modules or Tailwind).
+    - Preserve existing user-facing behavior while reducing coupling.
+  - Out of scope:
+    - Full app-wide visual redesign.
+    - Migrating every legacy component in one pass.
+- **Dependencies (backend/migration)**:
+  - Backend: None required.
+  - Migration: None.
+- **Definition of done**:
+  - `AppContent.tsx` complexity reduced via extracted modules and explicit interfaces.
+  - Chosen styling strategy documented and applied to touched files.
+  - Build/tests pass with no regressions in core gallery workflows.
+  - TODO references updated with completion status.
+
+## EIS-104 - Close local quality debt prior to backend expansion
+
+- **Source item**: "Close remaining local quality debt (`no-explicit-any`, `useImages`/`useStacks` closure and dependency issues)"
+- **Suggested owner/team**: Electron Frontend Quality
+- **Scope boundaries**:
+  - In scope:
+    - Eliminate remaining high-impact `no-explicit-any` warnings in active app code.
+    - Resolve known closure/dependency hazards in `useImages` and `useStacks`.
+    - Add/adjust lint rules or typed helpers where needed to prevent regressions.
+  - Out of scope:
+    - Whole-repo strict-mode migration.
+    - Purely cosmetic lint cleanups unrelated to runtime safety.
+- **Dependencies (backend/migration)**:
+  - Backend: None required.
+  - Migration: None.
+- **Definition of done**:
+  - Targeted lint/type debt list for this item is fully closed.
+  - Hook dependency/closure fixes are covered by tests or deterministic reproduction checks.
+  - CI/local lint pipeline passes for touched scope.
+  - TODO references updated with completion status.
+
+## EIS-105 - Execute embedding feature wave with backend coordination
+
+- **Source item**: "Execute embedding feature wave with backend coordination (Tag Propagation → Outlier Detection → 2D Map → Smart Stack Representative)"
+- **Suggested owner/team**: Cross-team (Electron Frontend + Python Backend/ML)
+- **Scope boundaries**:
+  - In scope:
+    - Sequence and track four feature deliverables: Tag Propagation, Outlier Detection, 2D Map, Smart Stack Representative.
+    - Define per-feature API contract expectations and rollout gating.
+    - Implement Electron UI/integration only for backend-ready endpoints.
+  - Out of scope:
+    - Inventing production ML algorithms inside Electron.
+    - Shipping features without agreed backend contract/versioning.
+- **Dependencies (backend/migration)**:
+  - Backend: Required for similarity/embedding endpoints and progress/event support.
+  - Migration: Potentially impacted by Firebird→Postgres milestones if embedding data paths change.
+- **Definition of done**:
+  - Each of the four features has: implemented UI path, integrated backend calls/events, and user-facing acceptance criteria met.
+  - Contract/version notes documented for cross-repo compatibility.
+  - Feature flags or rollout notes are documented if partial release is needed.
+  - TODO references updated with completion status.


### PR DESCRIPTION
### Motivation
- Provide an auditable, in-repo task register for the five highest-impact items listed in `TODO.md` so progress can be traced without an external issue tracker. 
- Make scope, cross-repo dependencies, definition of done, and ownership explicit for each high-impact item to reduce coordination friction during implementation.

### Description
- Added `docs/planning/03-high-impact-tracked-tasks.md` which defines tracked tasks `EIS-101` through `EIS-105`, each including scope boundaries, backend/migration dependencies, definition of done, and suggested owner/team. 
- Updated `TODO.md` to cross-link each of the five Highest-Impact Next Steps to the corresponding tracked task anchors and added the new tracked-task doc to the References section. 
- Kept the tracked tasks focused and scoped so they can be used as single-source-of-truth planning records for subsequent work.

### Testing
- Ran `git diff --check` which completed with no errors. 
- Verified file and anchor updates by inspecting `TODO.md` and the new `docs/planning/03-high-impact-tracked-tasks.md` contents using repository file queries and `sed`/`nl` checks, confirming the cross-links and task entries are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59323660c832382260f570bd02b75)