### PR TITLE
Add comprehensive unit tests for ApiClient, NefExtractor, and useNotificationStore

### DIFF
--- a/electron/nefExtractor.test.ts
+++ b/electron/nefExtractor.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock exiftool-vendored before importing the module under test
+vi.mock('exiftool-vendored', () => ({
+  exiftool: {
+    read: vi.fn(),
+    extractJpgFromRaw: vi.fn(),
+    write: vi.fn(),
+    end: vi.fn(),
+  },
+}));
+
+// Mock fs/promises
+vi.mock('fs/promises', () => ({
+  default: {
+    readFile: vi.fn(),
+    unlink: vi.fn(),
+  },
+  readFile: vi.fn(),
+  unlink: vi.fn(),
+}));
+
+import { exiftool } from 'exiftool-vendored';
+import fs from 'fs/promises';
+
+// Force a fresh singleton for each describe block
+let NefExtractor: typeof import('./nefExtractor').NefExtractor;
+let nefExtractor: import('./nefExtractor').NefExtractor;
+
+describe('NefExtractor', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Ensure the singleton is reset between tests by reimporting
+    vi.resetModules();
+    const mod = await import('./nefExtractor');
+    NefExtractor = mod.NefExtractor;
+    nefExtractor = NefExtractor.getInstance();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getInstance', () => {
+    it('returns the same instance on repeated calls', () => {
+      const a = NefExtractor.getInstance();
+      const b = NefExtractor.getInstance();
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('extractPreview', () => {
+    it('returns a Buffer on successful extraction without rotation', async () => {
+      const fakeBuffer = Buffer.from('jpeg-data');
+      vi.mocked(exiftool.read).mockResolvedValue({ Orientation: '1' } as never);
+      vi.mocked(exiftool.extractJpgFromRaw).mockResolvedValue(undefined as never);
+      vi.mocked(fs.readFile).mockResolvedValue(fakeBuffer as never);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await nefExtractor.extractPreview('/path/to/photo.nef');
+
+      expect(result).toBe(fakeBuffer);
+      expect(exiftool.read).toHaveBeenCalledWith('/path/to/photo.nef');
+      expect(exiftool.extractJpgFromRaw).toHaveBeenCalled();
+      // No write call because orientation is '1' (horizontal/normal)
+      expect(exiftool.write).not.toHaveBeenCalled();
+    });
+
+    it('applies orientation tag when orientation is not normal', async () => {
+      const fakeBuffer = Buffer.from('rotated-jpeg');
+      vi.mocked(exiftool.read).mockResolvedValue({ Orientation: 'Rotate 90 CW' } as never);
+      vi.mocked(exiftool.extractJpgFromRaw).mockResolvedValue(undefined as never);
+      vi.mocked(exiftool.write).mockResolvedValue(undefined as never);
+      vi.mocked(fs.readFile).mockResolvedValue(fakeBuffer as never);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await nefExtractor.extractPreview('/path/to/photo.nef');
+
+      expect(result).toBe(fakeBuffer);
+      expect(exiftool.write).toHaveBeenCalledWith(
+        expect.any(String),
+        { Orientation: 'Rotate 90 CW' },
+        ['-overwrite_original']
+      );
+    });
+
+    it('skips orientation write when orientation is "Horizontal (normal)"', async () => {
+      const fakeBuffer = Buffer.from('normal-jpeg');
+      vi.mocked(exiftool.read).mockResolvedValue({ Orientation: 'Horizontal (normal)' } as never);
+      vi.mocked(exiftool.extractJpgFromRaw).mockResolvedValue(undefined as never);
+      vi.mocked(fs.readFile).mockResolvedValue(fakeBuffer as never);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      const result = await nefExtractor.extractPreview('/path/to/photo.nef');
+
+      expect(exiftool.write).not.toHaveBeenCalled();
+      expect(result).toBe(fakeBuffer);
+    });
+
+    it('returns null when exiftool.read throws', async () => {
+      vi.mocked(exiftool.read).mockRejectedValue(new Error('exiftool error'));
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await nefExtractor.extractPreview('/bad/path.nef');
+
+      expect(result).toBeNull();
+      consoleSpy.mockRestore();
+    });
+
+    it('returns null and emits ENOENT message when file is missing', async () => {
+      const enoentErr = Object.assign(new Error('no such file'), { code: 'ENOENT' });
+      vi.mocked(exiftool.read).mockRejectedValue(enoentErr);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await nefExtractor.extractPreview('/missing.nef');
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('File not found')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('cleans up temp file even when extraction fails', async () => {
+      vi.mocked(exiftool.read).mockRejectedValue(new Error('fail'));
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+      vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await nefExtractor.extractPreview('/path.nef');
+
+      expect(fs.unlink).toHaveBeenCalled();
+    });
+
+    it('cleans up temp file after successful extraction', async () => {
+      vi.mocked(exiftool.read).mockResolvedValue({ Orientation: 1 } as never);
+      vi.mocked(exiftool.extractJpgFromRaw).mockResolvedValue(undefined as never);
+      vi.mocked(fs.readFile).mockResolvedValue(Buffer.from('data') as never);
+      vi.mocked(fs.unlink).mockResolvedValue(undefined);
+
+      await nefExtractor.extractPreview('/photo.nef');
+
+      expect(fs.unlink).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup', () => {
+    it('calls exiftool.end on cleanup', async () => {
+      vi.mocked(exiftool.end).mockResolvedValue(undefined as never);
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      await nefExtractor.cleanup();
+
+      expect(exiftool.end).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('logs error if exiftool.end throws', async () => {
+      vi.mocked(exiftool.end).mockRejectedValue(new Error('cleanup fail'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await nefExtractor.cleanup();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Cleanup error'),
+        expect.any(Error)
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-gallery",
-  "version": "3.36.1",
+  "version": "3.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-gallery",
-      "version": "3.36.1",
+      "version": "3.38.0",
       "hasInstallScript": true,
       "dependencies": {
         "electron-is-dev": "^3.0.1",

--- a/src/services/apiClient.test.ts
+++ b/src/services/apiClient.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ApiClient } from './apiClient';
+
+type TestWindow = Window & typeof globalThis & {
+  electron?: {
+    getApiPort?: ReturnType<typeof vi.fn>;
+  };
+};
+
+// Private internals we access for testing
+interface ApiClientInternals {
+  reconnectAttempts: number;
+  ws: WebSocket | null;
+  reconnectTimeout: ReturnType<typeof setTimeout> | null;
+  connect: () => void;
+  scheduleReconnect: () => void;
+  getReconnectDelay: () => number;
+  disconnect: () => void;
+  on: (type: string, cb: (data: unknown) => void) => void;
+  off: (type: string, cb: (data: unknown) => void) => void;
+}
+
+let mockWs: {
+  url: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((e: MessageEvent) => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((e: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  _triggerOpen: () => void;
+  _triggerMessage: (obj: { type: string; data: unknown }) => void;
+};
+
+function createMockWs() {
+  return {
+    url: '',
+    readyState: 0,
+    onopen: null as (() => void) | null,
+    onmessage: null as ((e: MessageEvent) => void) | null,
+    onclose: null as (() => void) | null,
+    onerror: null as ((e: Event) => void) | null,
+    close: vi.fn(),
+    _triggerOpen() {
+      this.readyState = 1;
+      this.onopen?.();
+    },
+    _triggerMessage(obj: { type: string; data: unknown }) {
+      const event = new MessageEvent('message', { data: JSON.stringify(obj) });
+      this.onmessage?.(event);
+    },
+  };
+}
+
+describe('ApiClient', () => {
+  beforeEach(() => {
+    mockWs = createMockWs();
+
+    const MockWebSocket = class {
+      constructor(url: string) {
+        mockWs.url = url;
+        mockWs.readyState = 0;
+        return mockWs;
+      }
+    } as unknown as new (url: string) => WebSocket;
+
+    vi.stubGlobal('WebSocket', MockWebSocket);
+
+    (globalThis.window as TestWindow).electron = {
+      getApiPort: vi.fn().mockResolvedValue(7860),
+    };
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (globalThis.window as TestWindow).electron;
+    vi.useRealTimers();
+  });
+
+  it('connects to the default port when no electron api', async () => {
+    delete (globalThis.window as TestWindow).electron;
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockWs.url).toBe('ws://127.0.0.1:7860/ws/updates');
+    client.disconnect();
+  });
+
+  it('uses the port returned by getApiPort', async () => {
+    (globalThis.window as TestWindow).electron!.getApiPort = vi.fn().mockResolvedValue(9000);
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockWs.url).toContain(':9000/');
+    client.disconnect();
+  });
+
+  it('falls back to default port when getApiPort rejects', async () => {
+    (globalThis.window as TestWindow).electron!.getApiPort = vi.fn().mockRejectedValue(new Error('fail'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockWs.url).toBe('ws://127.0.0.1:7860/ws/updates');
+    client.disconnect();
+    consoleSpy.mockRestore();
+  });
+
+  it('resets reconnectAttempts to 0 on successful connection', async () => {
+    const client = new ApiClient() as unknown as ApiClientInternals;
+    await new Promise(resolve => setTimeout(resolve, 0));
+    client.reconnectAttempts = 5;
+    mockWs._triggerOpen();
+    expect(client.reconnectAttempts).toBe(0);
+    client.disconnect();
+  });
+
+  it('on() and off() register and unregister handlers', async () => {
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    mockWs._triggerOpen();
+
+    const handler = vi.fn();
+    client.on('test_event', handler);
+    mockWs._triggerMessage({ type: 'test_event', data: { x: 42 } });
+    expect(handler).toHaveBeenCalledWith({ x: 42 });
+
+    client.off('test_event', handler);
+    handler.mockClear();
+    mockWs._triggerMessage({ type: 'test_event', data: { x: 99 } });
+    expect(handler).not.toHaveBeenCalled();
+
+    client.disconnect();
+  });
+
+  it('dispatches to correct handler by event type', async () => {
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    mockWs._triggerOpen();
+
+    const handlerA = vi.fn();
+    const handlerB = vi.fn();
+    client.on('typeA', handlerA);
+    client.on('typeB', handlerB);
+
+    mockWs._triggerMessage({ type: 'typeA', data: 'a' });
+    expect(handlerA).toHaveBeenCalledWith('a');
+    expect(handlerB).not.toHaveBeenCalled();
+
+    mockWs._triggerMessage({ type: 'typeB', data: 'b' });
+    expect(handlerB).toHaveBeenCalledWith('b');
+
+    client.disconnect();
+  });
+
+  it('handles malformed JSON in onmessage without throwing', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    mockWs._triggerOpen();
+
+    expect(() =>
+      mockWs.onmessage?.(new MessageEvent('message', { data: 'not-json' }))
+    ).not.toThrow();
+
+    consoleSpy.mockRestore();
+    client.disconnect();
+  });
+
+  it('disconnect closes the WebSocket', async () => {
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    client.disconnect();
+    expect(mockWs.close).toHaveBeenCalled();
+  });
+
+  it('schedules a reconnect when the socket closes', async () => {
+    vi.useFakeTimers();
+    const client = new ApiClient();
+    await vi.runAllTimersAsync();
+    mockWs._triggerOpen();
+
+    mockWs.onclose?.();
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    client.disconnect();
+  });
+
+  it('stops connecting after max reconnection attempts', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new ApiClient() as unknown as ApiClientInternals;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    client.reconnectAttempts = 50;
+    client.connect();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Max reconnection attempts reached')
+    );
+
+    consoleSpy.mockRestore();
+    client.disconnect();
+  });
+
+  it('getReconnectDelay returns increasing values with jitter', async () => {
+    const client = new ApiClient() as unknown as ApiClientInternals;
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    client.reconnectAttempts = 0;
+    const delay0 = client.getReconnectDelay();
+    expect(delay0).toBeGreaterThanOrEqual(800);
+    expect(delay0).toBeLessThanOrEqual(1200);
+
+    client.reconnectAttempts = 1;
+    const delay1 = client.getReconnectDelay();
+    expect(delay1).toBeGreaterThanOrEqual(1600);
+    expect(delay1).toBeLessThanOrEqual(2400);
+
+    // Capped at maxReconnectInterval (30s ±20%)
+    client.reconnectAttempts = 20;
+    const delayMax = client.getReconnectDelay();
+    expect(delayMax).toBeLessThanOrEqual(36000);
+
+    client.disconnect();
+  });
+
+  it('multiple handlers for same event type all get called', async () => {
+    const client = new ApiClient();
+    await new Promise(resolve => setTimeout(resolve, 0));
+    mockWs._triggerOpen();
+
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    client.on('multi', h1);
+    client.on('multi', h2);
+
+    mockWs._triggerMessage({ type: 'multi', data: 'x' });
+    expect(h1).toHaveBeenCalledWith('x');
+    expect(h2).toHaveBeenCalledWith('x');
+
+    client.disconnect();
+  });
+});

--- a/src/store/useNotificationStore.test.ts
+++ b/src/store/useNotificationStore.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useNotificationStore } from './useNotificationStore';
+
+describe('useNotificationStore', () => {
+  beforeEach(() => {
+    useNotificationStore.getState().clearAll();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with no notifications', () => {
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('addNotification adds a notification with default type "info"', () => {
+    useNotificationStore.getState().addNotification('Hello');
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].message).toBe('Hello');
+    expect(notifications[0].type).toBe('info');
+    expect(notifications[0].id).toBeTruthy();
+    expect(notifications[0].timestamp).toBeGreaterThan(0);
+  });
+
+  it('addNotification accepts an explicit type', () => {
+    useNotificationStore.getState().addNotification('Error occurred', 'error');
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications[0].type).toBe('error');
+  });
+
+  it('addNotification prepends: newest is first', () => {
+    useNotificationStore.getState().addNotification('first');
+    useNotificationStore.getState().addNotification('second');
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications[0].message).toBe('second');
+    expect(notifications[1].message).toBe('first');
+  });
+
+  it('keeps at most 5 notifications', () => {
+    for (let i = 0; i < 7; i++) {
+      useNotificationStore.getState().addNotification(`msg ${i}`);
+    }
+    expect(useNotificationStore.getState().notifications).toHaveLength(5);
+  });
+
+  it('removeNotification removes the correct notification', () => {
+    useNotificationStore.getState().addNotification('A');
+    useNotificationStore.getState().addNotification('B');
+    const id = useNotificationStore.getState().notifications[0].id; // 'B' (newest first)
+    useNotificationStore.getState().removeNotification(id);
+    const { notifications } = useNotificationStore.getState();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].message).toBe('A');
+  });
+
+  it('removeNotification with unknown id leaves notifications unchanged', () => {
+    useNotificationStore.getState().addNotification('keep me');
+    useNotificationStore.getState().removeNotification('nonexistent-id');
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('clearAll removes all notifications', () => {
+    useNotificationStore.getState().addNotification('one');
+    useNotificationStore.getState().addNotification('two');
+    useNotificationStore.getState().clearAll();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('auto-removes notification after 5 seconds', () => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().addNotification('temporary');
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it('does not auto-remove before 5 seconds', () => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().addNotification('still here');
+    vi.advanceTimersByTime(4999);
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+  });
+
+  it('supports all notification types', () => {
+    const types = ['info', 'success', 'warning', 'error'] as const;
+    for (const type of types) {
+      useNotificationStore.getState().addNotification(`msg-${type}`, type);
+    }
+    const { notifications } = useNotificationStore.getState();
+    const seen = notifications.map(n => n.type);
+    for (const type of types) {
+      expect(seen).toContain(type);
+    }
+  });
+});


### PR DESCRIPTION
## Description

This PR adds comprehensive unit test coverage for three core modules:

### Tests Added

1. **ApiClient** (`src/services/apiClient.test.ts`)
   - WebSocket connection and reconnection logic
   - Port detection via Electron API with fallback to default
   - Event handler registration/deregistration (`on`/`off`)
   - Message dispatching to correct handlers
   - Error handling for malformed JSON
   - Reconnection delay calculation with exponential backoff and jitter
   - Max reconnection attempt limits

2. **NefExtractor** (`electron/nefExtractor.test.ts`)
   - JPEG preview extraction from NEF (Nikon) raw files
   - EXIF orientation tag handling and application
   - Error handling for missing files and extraction failures
   - Temporary file cleanup in success and failure paths
   - Singleton pattern enforcement
   - Graceful cleanup of exiftool resources

3. **useNotificationStore** (`src/store/useNotificationStore.test.ts`)
   - Notification creation with auto-generated IDs and timestamps
   - Type support (info, success, warning, error)
   - Notification removal by ID
   - Bulk clearing
   - Max capacity enforcement (5 notifications)
   - Auto-removal after 5 seconds
   - Prepend ordering (newest first)

### Test Coverage

All tests use Vitest with proper mocking:
- WebSocket mocking for ApiClient
- exiftool-vendored and fs/promises mocking for NefExtractor
- Zustand store state management for useNotificationStore
- Fake timers for time-dependent behavior

## Roadmap update checklist
- [ ] Counts recalculated
- [ ] Related TODO docs synced
- [ ] Dependency labels reviewed
- [ ] "Last evaluated" date updated

## Open-item totals and dependency split

**Before:** No unit tests for these modules

**After:** 511 lines of test coverage across 3 test files (240 + 173 + 98 lines)

## Test Plan

All tests pass with Vitest. No manual testing required—the test suite comprehensively covers the implemented functionality including edge cases, error paths, and timing-dependent behavior.

https://claude.ai/code/session_0162Mp2R3anvbN9TMDfLFhux