### PR TITLE
Add session log rotation and retention handling

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { nefExtractor } from './nefExtractor';
 import { ExifTool } from 'exiftool-vendored';
 import { ApiService } from './apiService';
 import { ExportImageContext } from './types';
+import { SessionLogManager } from './sessionLogManager';
 
 const exiftool = new ExifTool({ maxProcs: 2 });
 
@@ -18,6 +19,7 @@ const exiftool = new ExifTool({ maxProcs: 2 });
 
 let mainWindow: BrowserWindow | null = null;
 let currentExportImageContext: ExportImageContext | null = null;
+let sessionLogManager: SessionLogManager | null = null;
 
 function getDialogWindow(): BrowserWindow | null {
     const focused = BrowserWindow.getFocusedWindow();
@@ -615,8 +617,12 @@ app.whenReady().then(async () => {
 
     ipcMain.handle('debug:log', async (_, { level, message, data, timestamp }) => {
         const logDir = app.getPath('userData');
-        const dateStr = new Date().toISOString().split('T')[0];
-        const logFile = path.join(logDir, `session_${dateStr}.log`);
+
+        if (!sessionLogManager) {
+            sessionLogManager = new SessionLogManager(logDir);
+        }
+
+        const logFile = await sessionLogManager.getWritableLogPath(new Date());
 
         const logEntry = JSON.stringify({
             timestamp,

--- a/electron/sessionLogManager.test.ts
+++ b/electron/sessionLogManager.test.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_SESSION_LOG_POLICY, SessionLogManager, type SessionLogPolicy } from './sessionLogManager';
+
+const tempDirs: string[] = [];
+
+function createTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-log-manager-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeSizedFile(filePath: string, sizeInBytes: number) {
+  await fs.promises.writeFile(filePath, Buffer.alloc(sizeInBytes, 'x'));
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+});
+
+describe('SessionLogManager', () => {
+  it('uses base session log file until max size is reached, then rotates', async () => {
+    const logDir = createTempDir();
+    const policy: SessionLogPolicy = {
+      ...DEFAULT_SESSION_LOG_POLICY,
+      maxBytesPerFile: 50,
+      cleanupIntervalMs: Number.MAX_SAFE_INTEGER,
+    };
+
+    const manager = new SessionLogManager(logDir, policy);
+    const now = new Date('2026-03-15T12:00:00.000Z');
+
+    const firstPath = await manager.getWritableLogPath(now);
+    expect(path.basename(firstPath)).toBe('session_2026-03-15.log');
+
+    await writeSizedFile(firstPath, 50);
+
+    const rotatedPath = await manager.getWritableLogPath(now);
+    expect(path.basename(rotatedPath)).toBe('session_2026-03-15.1.log');
+  });
+
+  it('removes logs older than retention policy', async () => {
+    const logDir = createTempDir();
+    const manager = new SessionLogManager(logDir, {
+      ...DEFAULT_SESSION_LOG_POLICY,
+      retentionDays: 14,
+      cleanupIntervalMs: 0,
+    });
+
+    await fs.promises.mkdir(logDir, { recursive: true });
+    await writeSizedFile(path.join(logDir, 'session_2026-02-25.log'), 10);
+    await writeSizedFile(path.join(logDir, 'session_2026-03-14.log'), 10);
+
+    await manager.cleanupOldLogs(new Date('2026-03-15T00:00:00.000Z'));
+
+    const files = await fs.promises.readdir(logDir);
+    expect(files).toEqual(['session_2026-03-14.log']);
+  });
+
+  it('enforces maxFiles by removing oldest remaining logs', async () => {
+    const logDir = createTempDir();
+    const manager = new SessionLogManager(logDir, {
+      ...DEFAULT_SESSION_LOG_POLICY,
+      retentionDays: 365,
+      maxFiles: 3,
+      cleanupIntervalMs: 0,
+    });
+
+    await fs.promises.mkdir(logDir, { recursive: true });
+    await writeSizedFile(path.join(logDir, 'session_2026-03-10.log'), 10);
+    await writeSizedFile(path.join(logDir, 'session_2026-03-11.log'), 10);
+    await writeSizedFile(path.join(logDir, 'session_2026-03-12.log'), 10);
+    await writeSizedFile(path.join(logDir, 'session_2026-03-13.log'), 10);
+
+    await manager.cleanupOldLogs(new Date('2026-03-15T00:00:00.000Z'));
+
+    const files = (await fs.promises.readdir(logDir)).sort();
+    expect(files).toEqual([
+      'session_2026-03-11.log',
+      'session_2026-03-12.log',
+      'session_2026-03-13.log',
+    ]);
+  });
+});

--- a/electron/sessionLogManager.ts
+++ b/electron/sessionLogManager.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const LOG_PREFIX = 'session_';
+const LOG_EXTENSION = '.log';
+const LOG_FILE_PATTERN = /^session_(\d{4}-\d{2}-\d{2})(?:\.(\d+))?\.log$/;
+
+export interface SessionLogPolicy {
+    maxBytesPerFile: number;
+    retentionDays: number;
+    maxFiles: number;
+    cleanupIntervalMs: number;
+}
+
+export const DEFAULT_SESSION_LOG_POLICY: SessionLogPolicy = {
+    maxBytesPerFile: 5 * 1024 * 1024, // 5MB per file
+    retentionDays: 14,
+    maxFiles: 200,
+    cleanupIntervalMs: 5 * 60 * 1000 // 5 minutes
+};
+
+export class SessionLogManager {
+    private lastCleanupAt = 0;
+
+    constructor(private readonly logDir: string, private readonly policy: SessionLogPolicy = DEFAULT_SESSION_LOG_POLICY) { }
+
+    public async getWritableLogPath(now: Date): Promise<string> {
+        const dateStr = now.toISOString().split('T')[0];
+        const baseName = `${LOG_PREFIX}${dateStr}`;
+
+        await fs.promises.mkdir(this.logDir, { recursive: true });
+        await this.maybeCleanup(now);
+
+        const firstFile = path.join(this.logDir, `${baseName}${LOG_EXTENSION}`);
+        if (await this.canAppendToFile(firstFile)) {
+            return firstFile;
+        }
+
+        let suffix = 1;
+        while (true) {
+            const candidate = path.join(this.logDir, `${baseName}.${suffix}${LOG_EXTENSION}`);
+            if (await this.canAppendToFile(candidate)) {
+                return candidate;
+            }
+            suffix += 1;
+        }
+    }
+
+    private async maybeCleanup(now: Date): Promise<void> {
+        if (now.getTime() - this.lastCleanupAt < this.policy.cleanupIntervalMs) {
+            return;
+        }
+
+        await this.cleanupOldLogs(now);
+        this.lastCleanupAt = now.getTime();
+    }
+
+    private async canAppendToFile(filePath: string): Promise<boolean> {
+        try {
+            const stats = await fs.promises.stat(filePath);
+            return stats.size < this.policy.maxBytesPerFile;
+        } catch {
+            return true;
+        }
+    }
+
+    public async cleanupOldLogs(now: Date): Promise<void> {
+        const entries = await this.listSessionLogs();
+
+        if (entries.length === 0) {
+            return;
+        }
+
+        const cutoffTime = now.getTime() - this.policy.retentionDays * 24 * 60 * 60 * 1000;
+
+        const expired = entries.filter((entry) => entry.date.getTime() < cutoffTime);
+        await Promise.all(expired.map((entry) => fs.promises.rm(entry.filePath, { force: true })));
+
+        const remaining = entries
+            .filter((entry) => entry.date.getTime() >= cutoffTime)
+            .sort((a, b) => a.date.getTime() - b.date.getTime() || a.suffix - b.suffix);
+
+        if (remaining.length <= this.policy.maxFiles) {
+            return;
+        }
+
+        const overage = remaining.length - this.policy.maxFiles;
+        const toDelete = remaining.slice(0, overage);
+        await Promise.all(toDelete.map((entry) => fs.promises.rm(entry.filePath, { force: true })));
+    }
+
+    private async listSessionLogs(): Promise<Array<{ filePath: string; date: Date; suffix: number }>> {
+        const dirEntries = await fs.promises.readdir(this.logDir, { withFileTypes: true }).catch(() => []);
+
+        return dirEntries
+            .filter((entry) => entry.isFile())
+            .map((entry) => {
+                const match = entry.name.match(LOG_FILE_PATTERN);
+                if (!match) {
+                    return null;
+                }
+
+                const [, datePart, suffixPart] = match;
+                const parsedDate = new Date(`${datePart}T00:00:00.000Z`);
+                if (Number.isNaN(parsedDate.getTime())) {
+                    return null;
+                }
+
+                return {
+                    filePath: path.join(this.logDir, entry.name),
+                    date: parsedDate,
+                    suffix: Number.parseInt(suffixPart ?? '0', 10)
+                };
+            })
+            .filter((entry): entry is { filePath: string; date: Date; suffix: number } => entry !== null);
+    }
+}


### PR DESCRIPTION
### Motivation
- Stabilize runtime observability by preventing unbounded session log growth and providing bounded retention/rotation for session logs as part of EIS-102.
- Ensure long-running sessions do not create huge single log files and provide sensible defaults for rotation and cleanup.
- Provide a centralized, testable utility to manage session log selection and lifecycle.

### Description
- Add `electron/sessionLogManager.ts` which implements `SessionLogManager` supporting size-based rotation, date-based naming (`session_YYYY-MM-DD.log` → `.1`, `.2`, ...), retention-based cleanup, and `maxFiles` enforcement, with a configurable policy (defaults: `5MB` per file, `14` days retention, `200` files, cleanup every `5` minutes).
- Wire `debug:log` IPC handler in `electron/main.ts` to use `SessionLogManager` to obtain a writable log path before appending entries so writes are bounded and rotated.
- Add unit tests in `electron/sessionLogManager.test.ts` covering rotation on max size, removal of logs older than retention, and enforcement of `maxFiles`.

### Testing
- Ran unit tests with `npm run test:run -- electron/sessionLogManager.test.ts`, and all tests passed (3 tests).
- Ran repository lint via `npm run lint`; lint failed due to pre-existing unrelated lint errors in other parts of the repo (these errors were not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b63abae8d48323b6aa56496754993d)