### PR TITLE
Add processing page with pipeline phase controls and live monitoring

### DIFF
--- a/electron/apiService.ts
+++ b/electron/apiService.ts
@@ -11,6 +11,7 @@ import type {
     ApiResponse,
     HealthResponse,
     StatusResponse,
+    AllRunnersStatus,
     ScoringStartRequest,
     SingleImageRequest,
     TaggingStartRequest,
@@ -25,6 +26,8 @@ import type {
     ImportRegisterRequest,
     ImportRegisterResponse,
     PipelineSubmitRequest,
+    PipelinePhaseControlRequest,
+    QueueResponse,
     JobInfo,
     DatabaseStats,
 } from './apiTypes';
@@ -221,6 +224,14 @@ export class ApiService {
         return this.post<ApiResponse>('/api/pipeline/submit', opts, LONG_TIMEOUT);
     }
 
+    skipPipelinePhase(opts: PipelinePhaseControlRequest) {
+        return this.post<ApiResponse>('/api/pipeline/phase/skip', opts);
+    }
+
+    retryPipelinePhase(opts: PipelinePhaseControlRequest) {
+        return this.post<ApiResponse>('/api/pipeline/phase/retry', opts);
+    }
+
     // ── Duplicates & Similarity ─────────────────────────────────────────────
 
     findDuplicates(opts?: FindDuplicatesRequest) {
@@ -279,7 +290,20 @@ export class ApiService {
         return this.get<DatabaseStats>('/api/stats');
     }
 
+    /** Returns combined status for all runners (scoring + tagging). */
+    getAllStatus() {
+        return this.get<AllRunnersStatus>('/api/status');
+    }
+
     // ── Jobs ────────────────────────────────────────────────────────────────
+
+    getJobsQueue(limit?: number) {
+        return this.get<QueueResponse>('/api/jobs/queue', limit !== undefined ? { limit } : undefined);
+    }
+
+    cancelJob(jobId: string | number) {
+        return this.post<ApiResponse>(`/api/jobs/${jobId}/cancel`);
+    }
 
     getRecentJobs() {
         return this.get<JobInfo[]>('/api/jobs/recent').then((jobs) =>

--- a/electron/apiTypes.ts
+++ b/electron/apiTypes.ts
@@ -153,6 +153,14 @@ export interface ImportRegisterResponse {
 
 // ── Pipeline ────────────────────────────────────────────────────────────────
 
+export interface PipelinePhaseControlRequest {
+    input_path: string;
+    /** Phase code as used by backend: 'indexing' | 'metadata' | 'score' | 'tag' | 'cluster' */
+    phase_code: string;
+    reason?: string | null;
+    actor?: string | null;
+}
+
 export interface PipelineSubmitRequest {
     input_path: string;
     operations?: string[];
@@ -160,6 +168,14 @@ export interface PipelineSubmitRequest {
     custom_keywords?: string[] | null;
     generate_captions?: boolean;
     clustering_threshold?: number | null;
+}
+
+// ── All-runners status ───────────────────────────────────────────────────────
+
+export interface AllRunnersStatus {
+    scoring: StatusResponse & { available?: boolean };
+    tagging: StatusResponse & { available?: boolean };
+    [key: string]: unknown;
 }
 
 // ── Jobs ────────────────────────────────────────────────────────────────────
@@ -175,6 +191,14 @@ export interface JobInfo {
     completed_at?: string;
     log?: string;
     progress?: { current: number; total: number };
+    [key: string]: unknown;
+}
+
+// ── Queue ────────────────────────────────────────────────────────────────────
+
+export interface QueueResponse {
+    queue_depth: number;
+    jobs: JobInfo[];
     [key: string]: unknown;
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -207,6 +207,14 @@ const rebuildApplicationMenu = () => {
                             mainWindow.webContents.send('open-duplicates');
                         }
                     }
+                },
+                {
+                    label: 'Processing',
+                    click: () => {
+                        if (mainWindow) {
+                            mainWindow.webContents.send('open-processing');
+                        }
+                    }
                 }
             ]
         },
@@ -805,7 +813,27 @@ app.whenReady().then(async () => {
         return await apiService.submitPipeline(opts);
     }));
 
+    ipcMain.handle('api:pipeline-skip', wrapIpcHandler(async (_, opts) => {
+        return await apiService.skipPipelinePhase(opts);
+    }));
+
+    ipcMain.handle('api:pipeline-retry', wrapIpcHandler(async (_, opts) => {
+        return await apiService.retryPipelinePhase(opts);
+    }));
+
     // Jobs
+    ipcMain.handle('api:status-all', wrapIpcHandler(async () => {
+        return await apiService.getAllStatus();
+    }));
+
+    ipcMain.handle('api:jobs-queue', wrapIpcHandler(async (_, limit?: number) => {
+        return await apiService.getJobsQueue(limit);
+    }));
+
+    ipcMain.handle('api:job-cancel', wrapIpcHandler(async (_, jobId: string | number) => {
+        return await apiService.cancelJob(jobId);
+    }));
+
     ipcMain.handle('api:jobs-recent', wrapIpcHandler(async () => {
         return await apiService.getRecentJobs();
     }));

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,12 +4,15 @@ import type {
     ApiResponse as BackendApiResponse,
     HealthResponse,
     StatusResponse,
+    AllRunnersStatus,
     ScoringStartRequest,
     TaggingStartRequest,
     TaggingSingleRequest,
     TagPropagationRequest,
     ClusteringStartRequest,
     PipelineSubmitRequest,
+    PipelinePhaseControlRequest,
+    QueueResponse,
     JobInfo,
     DatabaseStats,
     SimilarSearchResult,
@@ -137,6 +140,13 @@ contextBridge.exposeInMainWorld('electron', {
             ipcRenderer.removeListener('open-duplicates', handler);
         };
     },
+    onOpenProcessing: (callback: () => void) => {
+        const handler = () => callback();
+        ipcRenderer.on('open-processing', handler);
+        return () => {
+            ipcRenderer.removeListener('open-processing', handler);
+        };
+    },
     onImportFolderSelected: (callback: (folderPath: string) => void) => {
         const handler = (_: unknown, folderPath: string) => callback(folderPath);
         ipcRenderer.on('import:folder-selected', handler);
@@ -241,6 +251,14 @@ contextBridge.exposeInMainWorld('electron', {
             const r = await ipcRenderer.invoke('api:pipeline-submit', opts);
             return unwrapEnvelope<BackendApiResponse>(r);
         },
+        skipPipelinePhase: async (opts: PipelinePhaseControlRequest) => {
+            const r = await ipcRenderer.invoke('api:pipeline-skip', opts);
+            return unwrapEnvelope<BackendApiResponse>(r);
+        },
+        retryPipelinePhase: async (opts: PipelinePhaseControlRequest) => {
+            const r = await ipcRenderer.invoke('api:pipeline-retry', opts);
+            return unwrapEnvelope<BackendApiResponse>(r);
+        },
 
         // Jobs
         getRecentJobs: async () => {
@@ -250,6 +268,18 @@ contextBridge.exposeInMainWorld('electron', {
         getJobDetail: async (jobId: string | number) => {
             const r = await ipcRenderer.invoke('api:job-detail', jobId);
             return unwrapEnvelope<JobInfo>(r);
+        },
+        getAllStatus: async () => {
+            const r = await ipcRenderer.invoke('api:status-all');
+            return unwrapEnvelope<AllRunnersStatus>(r);
+        },
+        getJobsQueue: async (limit?: number) => {
+            const r = await ipcRenderer.invoke('api:jobs-queue', limit);
+            return unwrapEnvelope<QueueResponse>(r);
+        },
+        cancelJob: async (jobId: string | number) => {
+            const r = await ipcRenderer.invoke('api:job-cancel', jobId);
+            return unwrapEnvelope<BackendApiResponse>(r);
         },
     },
 });

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -13,6 +13,7 @@ import { useJobProgressStore } from './store/useJobProgressStore';
 import { NotificationTray } from './components/Layout/NotificationTray';
 import { SettingsModal } from './components/Settings/SettingsModal';
 import { DuplicateFinder } from './components/Duplicates/DuplicateFinder';
+import { ProcessingPage } from './components/Processing/ProcessingPage';
 import { ImportModal } from './components/Import/ImportModal';
 import { Loader2, ChevronRight } from 'lucide-react';
 import breadcrumbStyles from './styles/breadcrumbs.module.css';
@@ -56,7 +57,7 @@ function AppContent({ isConnected }: AppContentProps) {
   const [currentImageIndex, setCurrentImageIndex] = useState<number>(0);
   const [initialSimilarSearchImageId, setInitialSimilarSearchImageId] = useState<number | null>(null);
   const [pendingOpenImageId, setPendingOpenImageId] = useState<number | null>(null);
-  const [currentView, setCurrentView] = useState<'gallery' | 'duplicates'>('gallery');
+  const [currentView, setCurrentView] = useState<'gallery' | 'duplicates' | 'processing'>('gallery');
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
@@ -78,6 +79,13 @@ function AppContent({ isConnected }: AppContentProps) {
       });
     }
 
+    let cleanupProcessing: (() => void) | undefined;
+    if (window.electron?.onOpenProcessing) {
+      cleanupProcessing = window.electron.onOpenProcessing(() => {
+        setCurrentView('processing');
+      });
+    }
+
     let cleanupImport: (() => void) | undefined;
     if (window.electron?.onImportFolderSelected) {
       cleanupImport = window.electron.onImportFolderSelected((path) => {
@@ -96,6 +104,7 @@ function AppContent({ isConnected }: AppContentProps) {
     return () => {
       if (cleanupSettings) cleanupSettings();
       if (cleanupDuplicates) cleanupDuplicates();
+      if (cleanupProcessing) cleanupProcessing();
       if (cleanupImport) cleanupImport();
       if (cleanupNotification) cleanupNotification();
     };
@@ -754,7 +763,14 @@ function AppContent({ isConnected }: AppContentProps) {
         }
         content={
           <div style={{ height: '100%', overflow: 'hidden', position: 'relative', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-            {currentView === 'duplicates' ? (
+            {currentView === 'processing' ? (
+              <ProcessingPage
+                folders={folders}
+                foldersLoading={foldersLoading}
+                onRefreshFolders={refreshFolders}
+                onBackToGallery={() => setCurrentView('gallery')}
+              />
+            ) : currentView === 'duplicates' ? (
               <DuplicateFinder currentFolder={currentFolder} />
             ) : (
               <>

--- a/src/components/Processing/ProcessingConsole.tsx
+++ b/src/components/Processing/ProcessingConsole.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from 'react';
+import type { WorkerLogEntry } from '../../store/useProcessingStore';
+
+interface ProcessingConsoleProps {
+    entries: WorkerLogEntry[];
+    onClear: () => void;
+}
+
+const LEVEL_COLOR: Record<WorkerLogEntry['level'], string> = {
+    info: '#ccc',
+    warn: '#f0a500',
+    error: '#e05050',
+};
+
+export function ProcessingConsole({ entries, onClear }: ProcessingConsoleProps) {
+    const bottomRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [entries.length]);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+            <div style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                padding: '6px 10px', borderBottom: '1px solid #333', flexShrink: 0,
+            }}>
+                <span style={{ fontSize: '0.8em', color: '#888', fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                    Worker Log
+                </span>
+                <button
+                    onClick={onClear}
+                    style={{
+                        background: 'none', border: 'none', color: '#666', cursor: 'pointer',
+                        fontSize: '0.75em', padding: '2px 6px',
+                    }}
+                >
+                    Clear
+                </button>
+            </div>
+            <div style={{
+                flex: 1, overflowY: 'auto', fontFamily: 'monospace', fontSize: '0.78em',
+                padding: '6px 10px', background: '#0d0d0d', lineHeight: 1.5,
+            }}>
+                {entries.length === 0 ? (
+                    <div style={{ color: '#444', fontStyle: 'italic' }}>No log entries yet.</div>
+                ) : (
+                    entries.map((entry, i) => (
+                        <div key={i} style={{ color: LEVEL_COLOR[entry.level], marginBottom: 1 }}>
+                            <span style={{ color: '#555', marginRight: 8 }}>
+                                {new Date(entry.ts).toLocaleTimeString()}
+                            </span>
+                            <span style={{ color: '#666', marginRight: 8 }}>[{entry.source}]</span>
+                            {entry.message}
+                        </div>
+                    ))
+                )}
+                <div ref={bottomRef} />
+            </div>
+        </div>
+    );
+}

--- a/src/components/Processing/ProcessingControls.tsx
+++ b/src/components/Processing/ProcessingControls.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useNotificationStore } from '../../store/useNotificationStore';
+import { useProcessingStore } from '../../store/useProcessingStore';
+
+interface ProcessingControlsProps {
+    folderPath: string | null;
+    onBack: () => void;
+}
+
+export function ProcessingControls({ folderPath, onBack }: ProcessingControlsProps) {
+    const [busy, setBusy] = useState(false);
+    const addNotification = useNotificationStore((s) => s.addNotification);
+    const { actor, setActor, appendLog } = useProcessingStore((s) => ({
+        actor: s.actor,
+        setActor: s.setActor,
+        appendLog: s.appendLog,
+    }));
+
+    const logEntry = (message: string, level: 'info' | 'warn' | 'error' = 'info') => {
+        appendLog({ ts: new Date().toISOString(), level, source: 'system', message });
+    };
+
+    const handleRunAll = async () => {
+        if (!folderPath || busy) return;
+        setBusy(true);
+        try {
+            await window.electron.api.submitPipeline({
+                input_path: folderPath,
+                operations: ['indexing', 'metadata', 'score', 'tag', 'cluster'],
+                skip_existing: true,
+            });
+            addNotification('Pipeline submitted', 'success');
+            logEntry(`Run All Pending → ${folderPath}`);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            addNotification(`Pipeline submit failed: ${msg}`, 'error');
+            logEntry(`Run All Pending failed: ${msg}`, 'error');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleStopAll = async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await Promise.allSettled([
+                window.electron.api.stopScoring(),
+                window.electron.api.stopTagging(),
+                window.electron.api.stopClustering(),
+            ]);
+            addNotification('Stop signal sent', 'info');
+            logEntry('Stop All → stop signals sent');
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            addNotification(`Stop failed: ${msg}`, 'error');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div style={{
+            display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap',
+            padding: '10px 14px', borderBottom: '1px solid #333', background: '#141414',
+        }}>
+            <button
+                onClick={onBack}
+                style={{ background: 'none', border: 'none', color: '#888', cursor: 'pointer', fontSize: '0.85em' }}
+            >
+                ← Gallery
+            </button>
+
+            <div style={{ width: 1, height: 20, background: '#333' }} />
+
+            <button
+                onClick={handleRunAll}
+                disabled={!folderPath || busy}
+                style={{
+                    background: !folderPath || busy ? '#333' : '#2a5faa',
+                    border: 'none', color: !folderPath || busy ? '#555' : '#eee',
+                    borderRadius: 5, padding: '5px 14px', fontSize: '0.85em',
+                    cursor: !folderPath || busy ? 'not-allowed' : 'pointer', fontWeight: 600,
+                }}
+            >
+                Run All Pending
+            </button>
+
+            <button
+                onClick={handleStopAll}
+                disabled={busy}
+                style={{
+                    background: busy ? '#333' : '#7a2020',
+                    border: 'none', color: busy ? '#555' : '#eee',
+                    borderRadius: 5, padding: '5px 14px', fontSize: '0.85em',
+                    cursor: busy ? 'not-allowed' : 'pointer',
+                }}
+            >
+                Stop All
+            </button>
+
+            <div style={{ flex: 1 }} />
+
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <label style={{ fontSize: '0.8em', color: '#888' }}>Actor:</label>
+                <input
+                    value={actor}
+                    onChange={(e) => setActor(e.target.value)}
+                    placeholder="your name"
+                    style={{
+                        background: '#111', border: '1px solid #444', color: '#eee',
+                        borderRadius: 4, padding: '4px 8px', fontSize: '0.82em', width: 120,
+                    }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/components/Processing/ProcessingPage.tsx
+++ b/src/components/Processing/ProcessingPage.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useCallback, useRef } from 'react';
+import { FolderTree } from '../Tree/FolderTree';
+import type { Folder } from '../Tree/treeUtils';
+import { ProcessingControls } from './ProcessingControls';
+import { ProcessingPhaseCard } from './ProcessingPhaseCard';
+import { ProcessingConsole } from './ProcessingConsole';
+import {
+    useProcessingStore,
+    PHASE_CODE_MAP,
+    ALL_PHASES,
+} from '../../store/useProcessingStore';
+
+interface ProcessingPageProps {
+    folders: Folder[];
+    foldersLoading: boolean;
+    onRefreshFolders: () => void;
+    onBackToGallery: () => void;
+}
+
+export function ProcessingPage({
+    folders,
+    foldersLoading,
+    onRefreshFolders,
+    onBackToGallery,
+}: ProcessingPageProps) {
+    const {
+        folderPath, phases, logBuffer, actor,
+        setFolder, updatePhase, appendLog, clearLog, setQueueDepth,
+    } = useProcessingStore();
+
+    // ── Hydrate initial status from API ───────────────────────────────────────
+
+    const hydrateStatus = useCallback(async () => {
+        try {
+            const status = await window.electron.api.getAllStatus();
+
+            // Update phases based on runner states
+            const runnerMap: Record<string, typeof status.scoring> = {
+                scoring: status.scoring,
+                tagging: status.tagging,
+            };
+
+            for (const [runnerName, runner] of Object.entries(runnerMap)) {
+                const phaseKey = runnerName === 'scoring' ? PHASE_CODE_MAP['score']
+                    : runnerName === 'tagging' ? PHASE_CODE_MAP['tag']
+                        : undefined;
+                if (!phaseKey) continue;
+
+                if (runner.is_running) {
+                    updatePhase(phaseKey, {
+                        status: 'running',
+                        processed: runner.progress?.current ?? 0,
+                        total: runner.progress?.total ?? 0,
+                        canRun: false,
+                        canSkip: true,
+                        canRetry: false,
+                    });
+                }
+            }
+
+            // Queue depth
+            try {
+                const queue = await window.electron.api.getJobsQueue();
+                setQueueDepth(queue.queue_depth ?? 0);
+            } catch {
+                // non-critical
+            }
+        } catch {
+            // Backend not available yet; phases remain at default
+        }
+    }, [updatePhase, setQueueDepth]);
+
+    useEffect(() => {
+        hydrateStatus();
+        const poll = setInterval(hydrateStatus, 10_000);
+        return () => clearInterval(poll);
+    }, [hydrateStatus]);
+
+    // ── WebSocket event subscription ──────────────────────────────────────────
+
+    const appendLogRef = useRef(appendLog);
+    appendLogRef.current = appendLog;
+    const updatePhaseRef = useRef(updatePhase);
+    updatePhaseRef.current = updatePhase;
+    // Track job_id → job_type: job_progress events don't include job_type
+    const jobTypeMapRef = useRef<Record<string, string>>({});
+
+    useEffect(() => {
+        let unsubFns: Array<() => void> = [];
+
+        import('../../services/WebSocketService').then(({ webSocketService: ws }) => {
+            const onStarted = (data: unknown) => {
+                const d = data as { job_id: string; job_type?: string; input_path?: string };
+                if (d.job_type) jobTypeMapRef.current[String(d.job_id)] = d.job_type;
+                appendLogRef.current({
+                    ts: new Date().toISOString(), level: 'info', source: 'pipeline',
+                    message: `Job started: ${d.job_type ?? 'unknown'} (id: ${d.job_id})`,
+                });
+                const phaseKey = d.job_type ? PHASE_CODE_MAP[d.job_type] : undefined;
+                if (phaseKey) {
+                    updatePhaseRef.current(phaseKey, {
+                        status: 'running', canRun: false, canSkip: true, canRetry: false,
+                        startedAt: new Date().toISOString(),
+                    });
+                }
+            };
+
+            const onProgress = (data: unknown) => {
+                const d = data as { job_id: string | number; current?: number; total?: number; message?: string };
+                const jobType = jobTypeMapRef.current[String(d.job_id)];
+                const phaseKey = jobType ? PHASE_CODE_MAP[jobType] : undefined;
+                if (phaseKey) {
+                    updatePhaseRef.current(phaseKey, {
+                        processed: d.current ?? 0,
+                        total: d.total ?? 0,
+                        message: d.message,
+                    });
+                }
+            };
+
+            const onCompleted = (data: unknown) => {
+                const d = data as { job_id: string; status?: string; error?: string };
+                const jobType = jobTypeMapRef.current[String(d.job_id)];
+                delete jobTypeMapRef.current[String(d.job_id)];
+                const succeeded = d.status === 'completed';
+                appendLogRef.current({
+                    ts: new Date().toISOString(),
+                    level: succeeded ? 'info' : 'error',
+                    source: 'pipeline',
+                    message: `Job ${succeeded ? 'completed' : 'failed'}: ${jobType ?? 'unknown'} (id: ${d.job_id})${d.error ? ` — ${d.error}` : ''}`,
+                });
+                const phaseKey = jobType ? PHASE_CODE_MAP[jobType] : undefined;
+                if (phaseKey) {
+                    updatePhaseRef.current(phaseKey, {
+                        status: succeeded ? 'done' : 'failed',
+                        canRun: !succeeded,
+                        canSkip: !succeeded,
+                        canRetry: !succeeded,
+                        endedAt: new Date().toISOString(),
+                    });
+                }
+            };
+
+            ws.on('job_started', onStarted);
+            ws.on('job_progress', onProgress);
+            ws.on('job_completed', onCompleted);
+
+            unsubFns = [
+                () => ws.off('job_started', onStarted),
+                () => ws.off('job_progress', onProgress),
+                () => ws.off('job_completed', onCompleted),
+            ];
+        }).catch(() => {
+            // WebSocket service not available
+        });
+
+        return () => unsubFns.forEach((fn) => fn());
+    }, []);
+
+    // ── Folder selection ──────────────────────────────────────────────────────
+
+    // Map folder path → folder id for FolderTree's selectedId prop
+    const selectedFolderByPath = folders
+        .flatMap(flattenFolders)
+        .find((f) => f.path === folderPath);
+
+    const handleSelectFolder = (folder: Folder) => {
+        setFolder(folder.path);
+    };
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+            {/* Top controls bar */}
+            <ProcessingControls folderPath={folderPath} onBack={onBackToGallery} />
+
+            <div style={{ display: 'flex', flex: 1, overflow: 'hidden', minHeight: 0 }}>
+                {/* Left: folder tree */}
+                <div style={{
+                    width: 220, flexShrink: 0, borderRight: '1px solid #2a2a2a',
+                    overflowY: 'auto', padding: '10px 0',
+                }}>
+                    {foldersLoading ? (
+                        <div style={{ color: '#666', padding: '8px 14px', fontSize: '0.85em' }}>Loading folders…</div>
+                    ) : (
+                        <FolderTree
+                            folders={folders}
+                            onSelect={handleSelectFolder}
+                            selectedId={selectedFolderByPath?.id}
+                            onRefresh={onRefreshFolders}
+                        />
+                    )}
+                </div>
+
+                {/* Right: phase cards + console */}
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', minHeight: 0 }}>
+                    {!folderPath ? (
+                        <div style={{
+                            flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            color: '#555', fontSize: '0.9em',
+                        }}>
+                            Select a folder to get started
+                        </div>
+                    ) : (
+                        <>
+                            {/* Phase cards */}
+                            <div style={{
+                                padding: 14, display: 'grid',
+                                gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+                                gap: 10, overflowY: 'auto', flexShrink: 0,
+                            }}>
+                                {ALL_PHASES.map((phaseKey) => {
+                                    const phaseState = phases.find((p) => p.phase === phaseKey)!;
+                                    return (
+                                        <ProcessingPhaseCard
+                                            key={phaseKey}
+                                            phase={phaseState}
+                                            folderPath={folderPath}
+                                            actor={actor}
+                                        />
+                                    );
+                                })}
+                            </div>
+
+                            {/* Log console */}
+                            <div style={{
+                                flex: 1, borderTop: '1px solid #2a2a2a',
+                                overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0,
+                            }}>
+                                <ProcessingConsole entries={logBuffer} onClear={clearLog} />
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function flattenFolders(folder: Folder): Folder[] {
+    return [folder, ...(folder.children ?? []).flatMap(flattenFolders)];
+}

--- a/src/components/Processing/ProcessingPhaseCard.tsx
+++ b/src/components/Processing/ProcessingPhaseCard.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+import { useNotificationStore } from '../../store/useNotificationStore';
+import { useProcessingStore, PHASE_LABELS, BACKEND_PHASE_CODE } from '../../store/useProcessingStore';
+import type { ProcessingPhaseState } from '../../store/useProcessingStore';
+
+interface ProcessingPhaseCardProps {
+    phase: ProcessingPhaseState;
+    folderPath: string;
+    actor: string;
+}
+
+const STATUS_COLOR: Record<string, string> = {
+    not_started: '#555',
+    queued: '#888',
+    running: '#4a9eff',
+    done: '#4caf50',
+    skipped: '#f0a500',
+    failed: '#e05050',
+};
+
+export function ProcessingPhaseCard({ phase, folderPath, actor }: ProcessingPhaseCardProps) {
+    const [skipReason, setSkipReason] = useState('');
+    const [showSkipInput, setShowSkipInput] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const addNotification = useNotificationStore((s) => s.addNotification);
+    const updatePhase = useProcessingStore((s) => s.updatePhase);
+    const appendLog = useProcessingStore((s) => s.appendLog);
+
+    const phaseCode = BACKEND_PHASE_CODE[phase.phase];
+    const label = PHASE_LABELS[phase.phase];
+    const pct = phase.total > 0 ? Math.round((phase.processed / phase.total) * 100) : 0;
+
+    const logEntry = (message: string, level: 'info' | 'warn' | 'error' = 'info') => {
+        appendLog({ ts: new Date().toISOString(), level, source: 'system', message });
+    };
+
+    const handleRun = async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await window.electron.api.submitPipeline({
+                input_path: folderPath,
+                operations: [phaseCode],
+                skip_existing: true,
+            });
+            logEntry(`${label}: submitted`);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            addNotification(`Failed to run ${label}: ${msg}`, 'error');
+            logEntry(`${label}: run failed — ${msg}`, 'error');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleSkip = async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await window.electron.api.skipPipelinePhase({
+                input_path: folderPath,
+                phase_code: phaseCode,
+                reason: skipReason || undefined,
+                actor: actor || undefined,
+            });
+            updatePhase(phase.phase, { status: 'skipped', canRun: false, canSkip: false, canRetry: true });
+            logEntry(`${label}: skipped${skipReason ? ` (${skipReason})` : ''}`);
+            setShowSkipInput(false);
+            setSkipReason('');
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            addNotification(`Failed to skip ${label}: ${msg}`, 'error');
+            logEntry(`${label}: skip failed — ${msg}`, 'error');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleRetry = async () => {
+        if (busy) return;
+        setBusy(true);
+        try {
+            await window.electron.api.retryPipelinePhase({
+                input_path: folderPath,
+                phase_code: phaseCode,
+                actor: actor || undefined,
+            });
+            updatePhase(phase.phase, { status: 'queued', canRun: false, canSkip: false, canRetry: false });
+            logEntry(`${label}: retry submitted`);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            addNotification(`Failed to retry ${label}: ${msg}`, 'error');
+            logEntry(`${label}: retry failed — ${msg}`, 'error');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div style={{
+            background: '#1a1a1a', border: '1px solid #333', borderRadius: 8,
+            padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 8,
+        }}>
+            {/* Header */}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <span style={{ fontWeight: 600, fontSize: '0.9em' }}>{label}</span>
+                <span style={{
+                    fontSize: '0.75em', fontWeight: 600,
+                    color: STATUS_COLOR[phase.status] ?? '#888',
+                    textTransform: 'uppercase', letterSpacing: '0.05em',
+                }}>
+                    {phase.status.replace('_', ' ')}
+                </span>
+            </div>
+
+            {/* Progress bar */}
+            {phase.total > 0 && (
+                <div>
+                    <div style={{ background: '#333', borderRadius: 4, height: 4, overflow: 'hidden' }}>
+                        <div style={{
+                            background: STATUS_COLOR[phase.status] ?? '#4a9eff',
+                            width: `${pct}%`, height: '100%', transition: 'width 0.3s',
+                        }} />
+                    </div>
+                    <div style={{ fontSize: '0.72em', color: '#666', marginTop: 3 }}>
+                        {phase.processed} / {phase.total} ({pct}%)
+                    </div>
+                </div>
+            )}
+
+            {/* Message */}
+            {phase.message && (
+                <div style={{ fontSize: '0.78em', color: '#888' }}>{phase.message}</div>
+            )}
+
+            {/* Actions */}
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                <button
+                    onClick={handleRun}
+                    disabled={!phase.canRun || busy}
+                    style={btnStyle(!phase.canRun || busy, 'primary')}
+                >
+                    Run
+                </button>
+                <button
+                    onClick={() => setShowSkipInput((v) => !v)}
+                    disabled={!phase.canSkip || busy}
+                    style={btnStyle(!phase.canSkip || busy, 'neutral')}
+                >
+                    Skip
+                </button>
+                <button
+                    onClick={handleRetry}
+                    disabled={!phase.canRetry || busy}
+                    style={btnStyle(!phase.canRetry || busy, 'neutral')}
+                >
+                    Retry
+                </button>
+            </div>
+
+            {/* Skip reason input */}
+            {showSkipInput && (
+                <div style={{ display: 'flex', gap: 6 }}>
+                    <input
+                        value={skipReason}
+                        onChange={(e) => setSkipReason(e.target.value)}
+                        placeholder="Reason (optional)"
+                        style={{
+                            flex: 1, background: '#111', border: '1px solid #444',
+                            color: '#eee', borderRadius: 4, padding: '4px 8px', fontSize: '0.82em',
+                        }}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleSkip(); }}
+                    />
+                    <button onClick={handleSkip} disabled={busy} style={btnStyle(busy, 'danger')}>
+                        Confirm Skip
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function btnStyle(disabled: boolean, variant: 'primary' | 'neutral' | 'danger') {
+    const colors = {
+        primary: disabled ? '#333' : '#2a5faa',
+        neutral: disabled ? '#333' : '#3a3a3a',
+        danger: disabled ? '#333' : '#7a2020',
+    };
+    return {
+        background: colors[variant],
+        border: 'none',
+        color: disabled ? '#555' : '#eee',
+        borderRadius: 4,
+        padding: '4px 10px',
+        fontSize: '0.8em',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+    } as const;
+}

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -143,6 +143,7 @@ declare global {
             readExif: (filePath: string) => Promise<Record<string, unknown>>;
             onOpenSettings: (callback: () => void) => () => void;
             onOpenDuplicates: (callback: () => void) => () => void;
+            onOpenProcessing: (callback: () => void) => () => void;
             onImportFolderSelected: (callback: (folderPath: string) => void) => () => void;
             importRun: (folderPath: string) => Promise<{ added: number; skipped: number; errors: string[] }>;
             onImportProgress: (callback: (data: { current: number; total: number; path?: string }) => void) => () => void;
@@ -175,10 +176,15 @@ declare global {
 
                 // Pipeline
                 submitPipeline: (opts: BackendPipelineSubmitRequest) => Promise<BackendApiResponse>;
+                skipPipelinePhase: (opts: BackendPipelinePhaseControlRequest) => Promise<BackendApiResponse>;
+                retryPipelinePhase: (opts: BackendPipelinePhaseControlRequest) => Promise<BackendApiResponse>;
 
                 // Jobs
                 getRecentJobs: () => Promise<BackendJobInfo[]>;
                 getJobDetail: (jobId: string | number) => Promise<BackendJobInfo>;
+                getAllStatus: () => Promise<BackendAllRunnersStatus>;
+                getJobsQueue: (limit?: number) => Promise<BackendQueueResponse>;
+                cancelJob: (jobId: string | number) => Promise<BackendApiResponse>;
             };
         };
     }
@@ -239,6 +245,25 @@ declare global {
         threshold?: number | null;
         time_gap?: number | null;
         force_rescan?: boolean;
+    }
+
+    interface BackendPipelinePhaseControlRequest {
+        input_path: string;
+        phase_code: string;
+        reason?: string | null;
+        actor?: string | null;
+    }
+
+    interface BackendAllRunnersStatus {
+        scoring: BackendStatusResponse & { available?: boolean };
+        tagging: BackendStatusResponse & { available?: boolean };
+        [key: string]: unknown;
+    }
+
+    interface BackendQueueResponse {
+        queue_depth: number;
+        jobs: BackendJobInfo[];
+        [key: string]: unknown;
     }
 
     interface BackendPipelineSubmitRequest {

--- a/src/store/useProcessingStore.ts
+++ b/src/store/useProcessingStore.ts
@@ -1,0 +1,139 @@
+import { create } from 'zustand';
+
+// ── Data contract (mirrors planning doc + backend phase codes) ───────────────
+
+/** Frontend phase keys used in UI. Backend uses different codes — see PHASE_CODE_MAP. */
+export type PhaseKey = 'index' | 'meta' | 'scoring' | 'culling' | 'keywords';
+
+/**
+ * Mapping from backend phase_code to frontend PhaseKey.
+ * Backend: 'indexing' | 'metadata' | 'score' | 'tag' | 'cluster'
+ */
+export const PHASE_CODE_MAP: Record<string, PhaseKey> = {
+    indexing: 'index',
+    metadata: 'meta',
+    score: 'scoring',
+    tag: 'keywords',
+    cluster: 'culling',
+};
+
+/**
+ * Mapping from frontend PhaseKey back to backend phase_code.
+ * Used when submitting single-phase run/skip/retry requests.
+ */
+export const BACKEND_PHASE_CODE: Record<PhaseKey, string> = {
+    index: 'indexing',
+    meta: 'metadata',
+    scoring: 'score',
+    keywords: 'tag',
+    culling: 'cluster',
+};
+
+/** Display labels for each phase. */
+export const PHASE_LABELS: Record<PhaseKey, string> = {
+    index: 'Index',
+    meta: 'Metadata',
+    scoring: 'Scoring',
+    keywords: 'Keywords',
+    culling: 'Culling',
+};
+
+export const ALL_PHASES: PhaseKey[] = ['index', 'meta', 'scoring', 'keywords', 'culling'];
+
+export type PhaseStatus = 'not_started' | 'queued' | 'running' | 'done' | 'skipped' | 'failed';
+
+export interface ProcessingPhaseState {
+    phase: PhaseKey;
+    status: PhaseStatus;
+    processed: number;
+    total: number;
+    startedAt?: string;
+    endedAt?: string;
+    message?: string;
+    canRun: boolean;
+    canSkip: boolean;
+    canRetry: boolean;
+}
+
+export interface WorkerLogEntry {
+    ts: string;
+    level: 'info' | 'warn' | 'error';
+    source: 'pipeline' | 'worker' | 'api' | 'system';
+    message: string;
+}
+
+const LOG_BUFFER_MAX = 500;
+
+function makeDefaultPhases(): ProcessingPhaseState[] {
+    return ALL_PHASES.map((phase) => ({
+        phase,
+        status: 'not_started',
+        processed: 0,
+        total: 0,
+        canRun: true,
+        canSkip: true,
+        canRetry: false,
+    }));
+}
+
+// ── Store interface ───────────────────────────────────────────────────────────
+
+interface ProcessingStore {
+    folderPath: string | null;
+    phases: ProcessingPhaseState[];
+    queueDepth: number;
+    logBuffer: WorkerLogEntry[];
+    actor: string;
+
+    setFolder: (path: string | null) => void;
+    setPhases: (phases: ProcessingPhaseState[]) => void;
+    updatePhase: (phase: PhaseKey, update: Partial<ProcessingPhaseState>) => void;
+    appendLog: (entry: WorkerLogEntry) => void;
+    clearLog: () => void;
+    setQueueDepth: (n: number) => void;
+    setActor: (actor: string) => void;
+    reset: () => void;
+}
+
+export const useProcessingStore = create<ProcessingStore>((set) => ({
+    folderPath: null,
+    phases: makeDefaultPhases(),
+    queueDepth: 0,
+    logBuffer: [],
+    actor: '',
+
+    setFolder: (path) =>
+        set({ folderPath: path, phases: makeDefaultPhases(), logBuffer: [] }),
+
+    setPhases: (phases) => set({ phases }),
+
+    updatePhase: (phase, update) =>
+        set((state) => ({
+            phases: state.phases.map((p) =>
+                p.phase === phase ? { ...p, ...update } : p,
+            ),
+        })),
+
+    appendLog: (entry) =>
+        set((state) => {
+            const next = [...state.logBuffer, entry];
+            return {
+                logBuffer: next.length > LOG_BUFFER_MAX ? next.slice(next.length - LOG_BUFFER_MAX) : next,
+            };
+        }),
+
+    clearLog: () => set({ logBuffer: [] }),
+
+    setQueueDepth: (n) => set({ queueDepth: n }),
+
+    setActor: (actor) => set({ actor }),
+
+    reset: () =>
+        set({
+            folderPath: null,
+            phases: makeDefaultPhases(),
+            queueDepth: 0,
+            logBuffer: [],
+            actor: '',
+        }),
+}));


### PR DESCRIPTION
## Overview
Adds a new Processing page that provides comprehensive pipeline management and monitoring capabilities. Users can now view and control individual processing phases (indexing, metadata, scoring, keywords, culling) with real-time progress tracking, live logging, and per-phase action controls (run, skip, retry).

## Changes

### New Components
- **ProcessingPage**: Main layout with folder tree navigation, phase cards grid, and live worker log console
- **ProcessingPhaseCard**: Individual phase status display with progress bar, action buttons, and skip reason input
- **ProcessingControls**: Top control bar with "Run All Pending", "Stop All", and actor name input
- **ProcessingConsole**: Real-time log viewer with color-coded severity levels and auto-scroll

### New Store
- **useProcessingStore**: Zustand store managing:
  - Selected folder path and phase states
  - Phase status tracking (not_started, queued, running, done, skipped, failed)
  - Progress metrics (processed/total counts)
  - Worker log buffer (max 500 entries)
  - Actor name for audit trail
  - Phase code mappings between frontend and backend

### Backend Integration
- **API endpoints**: Added support for:
  - `getAllStatus()`: Fetch combined runner status (scoring + tagging)
  - `getJobsQueue()`: Retrieve job queue depth
  - `skipPipelinePhase()`: Skip a specific phase with optional reason
  - `retryPipelinePhase()`: Retry a failed phase
  - `cancelJob()`: Cancel a specific job
- **WebSocket events**: Real-time updates via job_started, job_progress, job_completed events
- **Status polling**: 10-second interval polling for queue depth and runner status

### UI/UX Features
- Folder tree sidebar for navigation
- Phase cards with color-coded status indicators
- Progress bars with percentage and item counts
- Skip confirmation dialog with optional reason field
- Live worker log with timestamp, severity, and source tracking
- Disabled state management for buttons based on phase status
- Responsive grid layout for phase cards

### Menu Integration
- Added "Processing" menu item to main application menu

## Technical Details
- Phase state transitions managed through store updates
- WebSocket service dynamically imported to avoid circular dependencies
- Job type tracking via ref map to correlate progress events with phases
- Log buffer auto-truncation to prevent memory bloat
- Folder selection resets phase states and log buffer

## Test Plan
- Verify Processing page opens from menu and displays folder tree
- Test folder selection updates phase cards
- Confirm "Run All Pending" submits pipeline with all operations
- Test individual phase Run/Skip/Retry buttons trigger correct API calls
- Verify WebSocket events update phase progress in real-time
- Check log entries appear with correct timestamps and severity colors
- Test log buffer clear functionality
- Confirm actor name persists across phase operations

https://claude.ai/code/session_01YLd4YNYqmHX6JoVwHxniwn