### PR TITLE
Harden WebSocket reconnect lifecycle and clean related lint issues

### DIFF
--- a/mcp-server/src/tools/cdp.ts
+++ b/mcp-server/src/tools/cdp.ts
@@ -1,4 +1,4 @@
-import { sendCdpCommand, findPageTarget, listTargets } from "../utils/cdp.js";
+import { sendCdpCommand, findPageTarget } from "../utils/cdp.js";
 
 interface ToolDef {
     name: string;

--- a/src/services/WebSocketService.test.ts
+++ b/src/services/WebSocketService.test.ts
@@ -11,6 +11,7 @@ interface WebSocketServiceInternals {
   reconnectAttempts: number;
   handlers: Map<string, Set<(data: unknown) => void>>;
   reconnectTimeout: ReturnType<typeof setTimeout> | null;
+  intentionalDisconnect: boolean;
   getReconnectDelay: () => number;
   scheduleReconnect: () => void;
 }
@@ -68,6 +69,7 @@ describe('WebSocketService', () => {
       clearTimeout(service.reconnectTimeout);
       service.reconnectTimeout = null;
     }
+    service.intentionalDisconnect = false;
   });
 
   afterEach(() => {
@@ -142,6 +144,18 @@ describe('WebSocketService', () => {
       delay = service.getReconnectDelay();
       expect(delay).toBeGreaterThanOrEqual(24000); // 30000 - 6000 jitter
       expect(delay).toBeLessThanOrEqual(36000); // 30000 + 6000 jitter
+    });
+
+
+
+    it('does not schedule reconnect after intentional disconnect', async () => {
+      await webSocketService.connect();
+      mockWs._triggerOpen();
+
+      webSocketService.disconnect();
+      mockWs.onclose?.();
+
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it('schedules reconnect on close', async () => {

--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -41,6 +41,7 @@ class WebSocketService {
     private maxReconnectInterval: number = 30000; // 30 seconds
     private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
     private handlers: Map<string, Set<MessageHandler>> = new Map();
+    private intentionalDisconnect: boolean = false;
 
     constructor() {
     }
@@ -60,6 +61,8 @@ class WebSocketService {
     }
 
     public async connect() {
+        this.intentionalDisconnect = false;
+
         if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
             return;
         }
@@ -93,6 +96,11 @@ class WebSocketService {
             };
 
             this.ws.onclose = () => {
+                if (this.intentionalDisconnect) {
+                    console.log('[WebSocket] Disconnected intentionally');
+                    return;
+                }
+
                 console.log('[WebSocket] Disconnected, scheduling reconnect...');
                 this.scheduleReconnect();
             };
@@ -131,6 +139,8 @@ class WebSocketService {
     }
 
     public disconnect() {
+        this.intentionalDisconnect = true;
+
         if (this.reconnectTimeout) {
             clearTimeout(this.reconnectTimeout);
             this.reconnectTimeout = null;

--- a/src/store/useJobProgressStore.ts
+++ b/src/store/useJobProgressStore.ts
@@ -44,7 +44,8 @@ export const useJobProgressStore = create<JobProgressState>((set) => ({
         }),
     completeJob: (job_id) =>
         set((state) => {
-            const { [job_id]: _, ...rest } = state.activeJobs;
+            const { [job_id]: _removedJob, ...rest } = state.activeJobs;
+            void _removedJob;
             return { activeJobs: rest };
         }),
 }));


### PR DESCRIPTION
### Motivation
- Prevent the WebSocket client from automatically reconnecting after a user-initiated shutdown and clear a couple of small lint warnings encountered while touching related code.
- Ensure deliberate `disconnect()` calls do not leave scheduled reconnect timers that reopen sockets unexpectedly.

### Description
- Added an `intentionalDisconnect` flag to `WebSocketService` and reset it at the start of `connect()` so manual shutdowns do not trigger reconnect scheduling in `onclose`.
- Set `intentionalDisconnect` in `disconnect()` and early-return from `onclose` when the disconnect was intentional.
- Added a unit test that verifies no reconnect timers are scheduled after an intentional disconnect in `src/services/WebSocketService.test.ts`.
- Removed an unused `listTargets` import in `mcp-server/src/tools/cdp.ts` and fixed an unused destructured value in `useJobProgressStore.completeJob` to address lint warnings.

### Testing
- Ran the WebSocket unit tests with `npm run test:run -- src/services/WebSocketService.test.ts`, and all tests passed (`10 tests` passed).
- Linted the modified files with `npx eslint src/services/WebSocketService.ts src/services/WebSocketService.test.ts mcp-server/src/tools/cdp.ts src/store/useJobProgressStore.ts`, and no errors were reported for those files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b78cf3c3a88323a75d1f54d842eaef)