### PR TITLE
fix: remove duplicate score_ava SQL field and add per-folder phase status via scope/tree API

### DIFF
--- a/electron/apiService.ts
+++ b/electron/apiService.ts
@@ -31,6 +31,7 @@ import type {
     PhaseDecisionResponse,
     JobInfo,
     DatabaseStats,
+    ScopeTreeResponse,
 } from './apiTypes';
 import type { AppConfig } from './types';
 
@@ -331,5 +332,11 @@ export class ApiService {
 
     getRawPreview(filePath: string) {
         return this.get<unknown>('/api/raw-preview', { path: filePath });
+    }
+
+    // ── Scope Tree ──────────────────────────────────────────────────────────
+
+    getScopeTree() {
+        return this.get<ScopeTreeResponse>('/api/scope/tree');
     }
 }

--- a/electron/apiTypes.ts
+++ b/electron/apiTypes.ts
@@ -246,6 +246,21 @@ export interface QueueResponse {
     [key: string]: unknown;
 }
 
+// ── Scope Tree ──────────────────────────────────────────────────────────────
+
+/** Per-folder phase status summary returned by GET /api/scope/tree. */
+export interface FolderPhaseStatus {
+    folder_id: number;
+    folder_path: string;
+    indexing_status: string;
+    scoring_status: string;
+    tagging_status: string;
+}
+
+export interface ScopeTreeResponse {
+    folders: FolderPhaseStatus[];
+}
+
 // ── Stats ───────────────────────────────────────────────────────────────────
 
 /** Matches get_database_stats() from modules/mcp_server.py. Does not include scored_images or tagged_images. */

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -432,7 +432,6 @@ export async function getImages(options: ImageQueryOptions = {}): Promise<unknow
             i.score_aesthetic,
             i.score_spaq,
             i.score_ava,
-            i.score_ava,
             i.score_liqe,
             i.rating, 
             i.label, 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -848,6 +848,11 @@ app.whenReady().then(async () => {
         return await apiService.getJob(jobId);
     }));
 
+    // Scope tree (per-folder phase status from the backend phase summary table)
+    ipcMain.handle('api:get-scope-tree', wrapIpcHandler(async () => {
+        return await apiService.getScopeTree();
+    }));
+
     console.log('[Main] All IPC handlers registered. Creating window...');
     createWindow();
     rebuildApplicationMenu();

--- a/src/components/Tree/FolderTree.tsx
+++ b/src/components/Tree/FolderTree.tsx
@@ -3,6 +3,21 @@ import { ChevronRight, ChevronDown, Folder, FolderOpen, Trash2 } from 'lucide-re
 import type { Folder as FolderType } from './treeUtils';
 import { ConfirmDialog } from '../Shared/ConfirmDialog';
 
+const STATUS_COLOR: Record<string, string> = {
+    not_started: '#555',
+    queued: '#888',
+    running: '#4a9eff',
+    done: '#4caf50',
+    skipped: '#f0a500',
+    failed: '#e05050',
+};
+
+const PHASE_LABELS: [keyof Pick<FolderType, 'indexing_status' | 'scoring_status' | 'tagging_status'>, string][] = [
+    ['indexing_status', 'Indexing'],
+    ['scoring_status', 'Scoring'],
+    ['tagging_status', 'Tagging'],
+];
+
 interface FolderTreeProps {
     folders: FolderType[];
     onSelect: (folder: FolderType) => void;
@@ -84,6 +99,28 @@ const TreeNode: React.FC<{ node: FolderType; onSelect: (f: FolderType) => void; 
                 <span style={{ textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap', flex: 1 }}>
                     {node.title}
                 </span>
+
+                {PHASE_LABELS.some(([field]) => node[field] && node[field] !== 'not_started') && (
+                    <span style={{ display: 'flex', gap: 2, marginRight: 4 }}>
+                        {PHASE_LABELS.map(([field, label]) => {
+                            const status = node[field] ?? 'not_started';
+                            return (
+                                <span
+                                    key={field}
+                                    title={`${label}: ${status}`}
+                                    style={{
+                                        width: 6,
+                                        height: 6,
+                                        borderRadius: '50%',
+                                        backgroundColor: STATUS_COLOR[status] ?? STATUS_COLOR.not_started,
+                                        display: 'inline-block',
+                                        flexShrink: 0,
+                                    }}
+                                />
+                            );
+                        })}
+                    </span>
+                )}
 
                 {node.total_image_count === 0 && (
                     <button

--- a/src/components/Tree/treeUtils.ts
+++ b/src/components/Tree/treeUtils.ts
@@ -7,6 +7,9 @@ export interface Folder {
     total_image_count?: number;
     title?: string;
     children?: Folder[];
+    indexing_status?: string;
+    scoring_status?: string;
+    tagging_status?: string;
 }
 
 interface FolderRow {

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -185,6 +185,17 @@ declare global {
                 getAllStatus: () => Promise<BackendAllRunnersStatus>;
                 getJobsQueue: (limit?: number) => Promise<BackendQueueResponse>;
                 cancelJob: (jobId: string | number) => Promise<BackendApiResponse>;
+
+                // Scope tree
+                getScopeTree: () => Promise<{
+                    folders: Array<{
+                        folder_id: number;
+                        folder_path: string;
+                        indexing_status: string;
+                        scoring_status: string;
+                        tagging_status: string;
+                    }>;
+                }>;
             };
         };
     }

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -8,6 +8,9 @@ interface FolderRow {
     parent_id: number | null;
     is_fully_scored: number;
     image_count: number;
+    indexing_status?: string;
+    scoring_status?: string;
+    tagging_status?: string;
 }
 
 export function useFolders(): { folders: Folder[]; loading: boolean; refresh: () => void } {
@@ -17,8 +20,29 @@ export function useFolders(): { folders: Folder[]; loading: boolean; refresh: ()
     const fetchFolders = () => {
         if (!window.electron) return;
         setLoading(true);
-        window.electron.getFolders().then(res => {
-            setFlatFolders(res);
+
+        const foldersPromise = window.electron.getFolders();
+        const scopeTreePromise = window.electron.api.getScopeTree().catch(() => null);
+
+        Promise.all([foldersPromise, scopeTreePromise]).then(([folderRows, scopeTree]) => {
+            if (scopeTree?.folders?.length) {
+                const statusByPath = new Map(
+                    scopeTree.folders.map(f => [f.folder_path, f])
+                );
+                const merged: FolderRow[] = folderRows.map(row => {
+                    const phaseStatus = statusByPath.get(row.path);
+                    if (!phaseStatus) return row;
+                    return {
+                        ...row,
+                        indexing_status: phaseStatus.indexing_status,
+                        scoring_status: phaseStatus.scoring_status,
+                        tagging_status: phaseStatus.tagging_status,
+                    };
+                });
+                setFlatFolders(merged);
+            } else {
+                setFlatFolders(folderRows);
+            }
             setLoading(false);
         }).catch(err => {
             console.error('[useFolders] Failed to fetch folders:', err);


### PR DESCRIPTION
- Remove duplicate i.score_ava in getImages() SQL (copy-paste bug)
- Add FolderPhaseStatus + ScopeTreeResponse types to apiTypes.ts
- Add getScopeTree() method to ApiService calling GET /api/scope/tree
- Add api:get-scope-tree IPC handler in main.ts
- Declare getScopeTree in electron.d.ts window.electron.api
- Extend Folder/FolderRow types with optional indexing/scoring/tagging_status fields
- Merge phase statuses from scope tree into folder data in useFolders.ts (API failure is silent)
- Render 6px phase status dots (indexing, scoring, tagging) in FolderTree.tsx

https://claude.ai/code/session_01MwqRd92uCadrjTm5EYPeFV