### PR TITLE
Add secure Electron IPC bridge coverage for FastAPI operations

### DIFF
--- a/docs/integration/TODO.md
+++ b/docs/integration/TODO.md
@@ -4,6 +4,8 @@ Tasks for Electron ↔ Python backend integration. See [Agent Coordination](http
 
 ## REST API
 
+- [x] Bridge core FastAPI operations through secure Electron IPC (`window.electron.api.*`)
+- [x] Normalize backend HTTP errors through IPC envelope responses
 - [ ] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
 - [ ] Sync `electron/apiTypes.ts` when backend API contract changes
 

--- a/electron/apiBridgeValidators.test.ts
+++ b/electron/apiBridgeValidators.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { requireJobId, requireNonEmptyString } from './apiBridgeValidators';
+
+describe('apiBridgeValidators', () => {
+    it('accepts non-empty trimmed strings', () => {
+        expect(requireNonEmptyString('  hello  ', 'field')).toBe('hello');
+    });
+
+    it('rejects empty strings and non-strings', () => {
+        expect(() => requireNonEmptyString('', 'field')).toThrow('field must be a non-empty string');
+        expect(() => requireNonEmptyString(null, 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('accepts string and numeric job IDs', () => {
+        expect(requireJobId('  job-1 ')).toBe('job-1');
+        expect(requireJobId(42)).toBe(42);
+    });
+
+    it('rejects invalid job IDs', () => {
+        expect(() => requireJobId(Number.NaN)).toThrow('jobId must be a finite number or string');
+        expect(() => requireJobId('')).toThrow('jobId must be a non-empty string or finite number');
+    });
+});

--- a/electron/apiBridgeValidators.ts
+++ b/electron/apiBridgeValidators.ts
@@ -1,0 +1,21 @@
+export function requireNonEmptyString(value: unknown, fieldName: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new Error(`${fieldName} must be a non-empty string`);
+    }
+    return value.trim();
+}
+
+export function requireJobId(value: unknown): string | number {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+            throw new Error('jobId must be a finite number or string');
+        }
+        return value;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim();
+    }
+
+    throw new Error('jobId must be a non-empty string or finite number');
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,6 +8,7 @@ import { nefExtractor } from './nefExtractor';
 import { ExifTool } from 'exiftool-vendored';
 import { ApiService } from './apiService';
 import { ExportImageContext } from './types';
+import { requireJobId, requireNonEmptyString } from './apiBridgeValidators';
 
 const exiftool = new ExifTool({ maxProcs: 2 });
 
@@ -733,6 +734,10 @@ app.whenReady().then(async () => {
         return await apiService.getStatus();
     }));
 
+    ipcMain.handle('api:schema', wrapIpcHandler(async () => {
+        return await apiService.getSchema();
+    }));
+
     ipcMain.handle('api:stats', wrapIpcHandler(async () => {
         return await apiService.getStats();
     }));
@@ -751,7 +756,15 @@ app.whenReady().then(async () => {
     }));
 
     ipcMain.handle('api:scoring-single', wrapIpcHandler(async (_, filePath: string) => {
-        return await apiService.scoreSingleImage(filePath);
+        return await apiService.scoreSingleImage(requireNonEmptyString(filePath, 'filePath'));
+    }));
+
+    ipcMain.handle('api:scoring-fix-db', wrapIpcHandler(async () => {
+        return await apiService.fixScoringDb();
+    }));
+
+    ipcMain.handle('api:scoring-fix-image', wrapIpcHandler(async (_, filePath: string) => {
+        return await apiService.fixImage(requireNonEmptyString(filePath, 'filePath'));
     }));
 
     // Tagging
@@ -793,13 +806,42 @@ app.whenReady().then(async () => {
         return await apiService.submitPipeline(opts);
     }));
 
+    // Data reads
+    ipcMain.handle('api:images', wrapIpcHandler(async (_, params) => {
+        return await apiService.getImages(params);
+    }));
+
+    ipcMain.handle('api:image-detail', wrapIpcHandler(async (_, imageId: number) => {
+        return await apiService.getImageById(imageId);
+    }));
+
+    ipcMain.handle('api:folders', wrapIpcHandler(async () => {
+        return await apiService.getFolders();
+    }));
+
+    ipcMain.handle('api:stacks', wrapIpcHandler(async () => {
+        return await apiService.getStacks();
+    }));
+
+    ipcMain.handle('api:stack-images', wrapIpcHandler(async (_, stackId: number) => {
+        return await apiService.getStackImages(stackId);
+    }));
+
+    ipcMain.handle('api:import-register', wrapIpcHandler(async (_, folderPath: string) => {
+        return await apiService.importRegister({ folder_path: requireNonEmptyString(folderPath, 'folderPath') });
+    }));
+
     // Jobs
     ipcMain.handle('api:jobs-recent', wrapIpcHandler(async () => {
         return await apiService.getRecentJobs();
     }));
 
     ipcMain.handle('api:job-detail', wrapIpcHandler(async (_, jobId: string | number) => {
-        return await apiService.getJob(jobId);
+        return await apiService.getJob(requireJobId(jobId));
+    }));
+
+    ipcMain.handle('api:raw-preview', wrapIpcHandler(async (_, filePath: string) => {
+        return await apiService.getRawPreview(requireNonEmptyString(filePath, 'filePath'));
     }));
 
     console.log('[Main] All IPC handlers registered. Creating window...');

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -172,6 +172,10 @@ contextBridge.exposeInMainWorld('electron', {
             const r = await ipcRenderer.invoke('api:status');
             return unwrapEnvelope<StatusResponse>(r);
         },
+        getSchema: async () => {
+            const r = await ipcRenderer.invoke('api:schema');
+            return unwrapEnvelope<unknown>(r);
+        },
         getStats: async () => {
             const r = await ipcRenderer.invoke('api:stats');
             return unwrapEnvelope<DatabaseStats>(r);
@@ -192,6 +196,14 @@ contextBridge.exposeInMainWorld('electron', {
         },
         scoreSingleImage: async (filePath: string) => {
             const r = await ipcRenderer.invoke('api:scoring-single', filePath);
+            return unwrapEnvelope<BackendApiResponse>(r);
+        },
+        fixScoringDb: async () => {
+            const r = await ipcRenderer.invoke('api:scoring-fix-db');
+            return unwrapEnvelope<BackendApiResponse>(r);
+        },
+        fixImage: async (filePath: string) => {
+            const r = await ipcRenderer.invoke('api:scoring-fix-image', filePath);
             return unwrapEnvelope<BackendApiResponse>(r);
         },
 
@@ -237,6 +249,34 @@ contextBridge.exposeInMainWorld('electron', {
             return unwrapEnvelope<BackendApiResponse>(r);
         },
 
+        // Import
+        importRegister: async (folderPath: string) => {
+            const r = await ipcRenderer.invoke('api:import-register', folderPath);
+            return unwrapEnvelope<BackendApiResponse>(r);
+        },
+
+        // Data reads
+        getImages: async (params?: Record<string, string | number | undefined>) => {
+            const r = await ipcRenderer.invoke('api:images', params);
+            return unwrapEnvelope<unknown>(r);
+        },
+        getImageById: async (imageId: number) => {
+            const r = await ipcRenderer.invoke('api:image-detail', imageId);
+            return unwrapEnvelope<unknown>(r);
+        },
+        getFolders: async () => {
+            const r = await ipcRenderer.invoke('api:folders');
+            return unwrapEnvelope<unknown>(r);
+        },
+        getStacks: async () => {
+            const r = await ipcRenderer.invoke('api:stacks');
+            return unwrapEnvelope<unknown>(r);
+        },
+        getStackImages: async (stackId: number) => {
+            const r = await ipcRenderer.invoke('api:stack-images', stackId);
+            return unwrapEnvelope<unknown>(r);
+        },
+
         // Jobs
         getRecentJobs: async () => {
             const r = await ipcRenderer.invoke('api:jobs-recent');
@@ -245,6 +285,10 @@ contextBridge.exposeInMainWorld('electron', {
         getJobDetail: async (jobId: string | number) => {
             const r = await ipcRenderer.invoke('api:job-detail', jobId);
             return unwrapEnvelope<JobInfo>(r);
+        },
+        getRawPreview: async (filePath: string) => {
+            const r = await ipcRenderer.invoke('api:raw-preview', filePath);
+            return unwrapEnvelope<unknown>(r);
         },
     },
 });

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -148,6 +148,7 @@ declare global {
                 healthCheck: () => Promise<BackendHealthResponse>;
                 isAvailable: () => Promise<boolean>;
                 getStatus: () => Promise<BackendStatusResponse>;
+                getSchema: () => Promise<unknown>;
                 getStats: () => Promise<BackendDatabaseStats>;
 
                 // Scoring
@@ -155,6 +156,8 @@ declare global {
                 stopScoring: () => Promise<BackendApiResponse>;
                 getScoringStatus: () => Promise<BackendStatusResponse>;
                 scoreSingleImage: (filePath: string) => Promise<BackendApiResponse>;
+                fixScoringDb: () => Promise<BackendApiResponse>;
+                fixImage: (filePath: string) => Promise<BackendApiResponse>;
 
                 // Tagging
                 startTagging: (opts: BackendTaggingStartRequest) => Promise<BackendApiResponse>;
@@ -171,9 +174,20 @@ declare global {
                 // Pipeline
                 submitPipeline: (opts: BackendPipelineSubmitRequest) => Promise<BackendApiResponse>;
 
+                // Import
+                importRegister: (folderPath: string) => Promise<BackendApiResponse>;
+
+                // Data reads
+                getImages: (params?: Record<string, string | number | undefined>) => Promise<unknown>;
+                getImageById: (imageId: number) => Promise<unknown>;
+                getFolders: () => Promise<unknown>;
+                getStacks: () => Promise<unknown>;
+                getStackImages: (stackId: number) => Promise<unknown>;
+
                 // Jobs
                 getRecentJobs: () => Promise<BackendJobInfo[]>;
                 getJobDetail: (jobId: string | number) => Promise<BackendJobInfo>;
+                getRawPreview: (filePath: string) => Promise<unknown>;
             };
         };
     }


### PR DESCRIPTION
### Motivation
- Provide a robust bridge between the Electron main process and the Python FastAPI backend so the renderer can securely call backend operations via `window.electron.api.*`.
- Harden IPC input handling to avoid forwarding malformed or empty payloads to the backend by validating common parameters such as file paths and job IDs.
- Expose additional backend features (schema, raw preview, import registration, data reads, and repair endpoints) to the renderer in a typed, envelope-normalized way for consistent error handling.

### Description
- Added `electron/apiBridgeValidators.ts` with `requireNonEmptyString` and `requireJobId` to validate IPC payloads and a unit test file `electron/apiBridgeValidators.test.ts` that covers success and failure cases for both validators.
- Extended main-process IPC handlers in `electron/main.ts` to add handlers for `api:schema`, `api:scoring-fix-db`, `api:scoring-fix-image`, `api:import-register`, `api:images`, `api:image-detail`, `api:folders`, `api:stacks`, `api:stack-images`, `api:raw-preview`, and to validate parameters using the new validators before delegating to `ApiService`.
- Expanded the preload API in `electron/preload.ts` to expose the newly-bridged backend methods under `window.electron.api` and unwrap the standard IPC envelope for callers.
- Updated TypeScript declarations in `src/electron.d.ts` to include the new API surface and updated `docs/integration/TODO.md` to mark core bridge work as completed.

### Testing
- Ran unit tests for the validators with `npm run test -- electron/apiBridgeValidators.test.ts` and all tests passed (4 tests, 1 file).
- Verified type correctness with `npx tsc -p electron/tsconfig.json --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b809c4d0888323bf4453a009f56ef0)