### PR TITLE
docs: add `npm run test:run` to README development commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ This application provides a high-performance interface for browsing and filterin
 - `npm run dev`: Launch the app in development mode with HMR.
 - `npm run build`: Build the production application for Windows.
 - `npm run lint`: Run ESLint to check for code quality issues.
+- `npm run test:run`: Run the automated Vitest suite once.


### PR DESCRIPTION
### Motivation
- Make the one-shot Vitest command discoverable in the README so contributors can run the automated test suite quickly.

### Description
- Add a single line to `README.md` Development section documenting the `npm run test:run` command.

### Testing
- Ran `npm run test:run`; Vitest executed but the run failed due to pre-existing test issues unrelated to this documentation-only change: a missing import error in `src/services/apiClient.test.ts` and two failing tests in `src/hooks/useDataHooks.test.tsx` caused by an undefined `window.electron.api.getScopeTree` mock.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8271676e08323845bc7b7a9d986f9)