### PR TITLE
Refactor DB access behind provider interface

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,10 +1,22 @@
 {
     "database": {
+        "provider": "firebird",
         "host": "127.0.0.1",
         "port": 3050,
         "user": "sysdba",
         "password": "masterkey",
-        "path": "../image-scoring-backend/SCORING_HISTORY.FDB"
+        "path": "../image-scoring-backend/SCORING_HISTORY.FDB",
+        "postgres": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "user": "postgres",
+            "password": "postgres",
+            "database": "image_scoring",
+            "max": 10,
+            "idleTimeoutMillis": 30000,
+            "connectionTimeoutMillis": 10000,
+            "ssl": false
+        }
     },
     "dev": {
         "url": "http://localhost:5173"

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -2,7 +2,7 @@ import Firebird from 'node-firebird';
 import path from 'path';
 import fs from 'fs';
 
-import { createDbProvider, DbProvider, FirebirdProvider, QueryParam } from './db/provider';
+import { createDbProvider, DbProvider, QueryParam } from './db/provider';
 
 // Load configuration
 function loadConfig() {
@@ -205,11 +205,7 @@ export async function runTransaction<T>(
     callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
     isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED
 ): Promise<T> {
-    if (provider instanceof FirebirdProvider) {
-        return provider.runTransaction(callback, isolation);
-    }
-
-    throw new Error('runTransaction is currently only supported by the Firebird provider.');
+    return provider.runTransaction(callback, isolation);
 }
 
 function pushFolderFilter(

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1,8 +1,7 @@
-import Firebird from 'node-firebird';
 import path from 'path';
 import fs from 'fs';
 
-import { createDbProvider, DbProvider, QueryParam } from './db/provider';
+import { createDbProvider, DbProvider, QueryParam, TxQuery } from './db/provider';
 
 // Load configuration
 function loadConfig() {
@@ -181,14 +180,17 @@ const provider: DbProvider = createDbProvider({
     firebirdDatabasePath: dbPath,
 });
 
-export async function connectDB(): Promise<unknown> {
-    return provider.connect();
+export async function connectDB(): Promise<void> {
+    await provider.connect();
 }
 
 export function closeConnection(): void {
-    void provider.close();
+    void provider.close().catch((e) => {
+        console.error('[DB] Error while closing database connection:', e);
+    });
 }
 
+/** Historical name preserved for IPC compatibility; now validates whichever DB provider is configured. */
 export async function ensureFirebirdRunning(): Promise<boolean> {
     return provider.verifyStartup();
 }
@@ -202,10 +204,9 @@ export async function query<T = unknown>(sql: string, params: QueryParam[] = [])
 }
 
 export async function runTransaction<T>(
-    callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
-    isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED
+    callback: (txQuery: TxQuery) => Promise<T>
 ): Promise<T> {
-    return provider.runTransaction(callback, isolation);
+    return provider.runTransaction(callback);
 }
 
 function pushFolderFilter(
@@ -900,7 +901,7 @@ export async function rebuildStackCache(): Promise<number> {
         try {
             await ensureStackCacheTable();
 
-            return await runTransaction(async (tx, txQuery) => {
+            return await runTransaction(async (txQuery) => {
                 // Clear existing cache
                 await txQuery('DELETE FROM stack_cache');
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -2,8 +2,7 @@ import Firebird from 'node-firebird';
 import path from 'path';
 import fs from 'fs';
 
-import { spawn } from 'child_process';
-import net from 'net';
+import { createDbProvider, DbProvider, FirebirdProvider, QueryParam } from './db/provider';
 
 // Load configuration
 function loadConfig() {
@@ -159,7 +158,6 @@ function resolveSiblingDbPath(filename: string): string {
 // Add test detection — tests must NEVER use production DB
 const isTestEnv = process.env.NODE_ENV === 'test' || process.env.VITEST;
 
-// Database options
 // If path is relative in config, it's relative to the project root (one level up from dist-electron)
 let rawDbPath: string;
 
@@ -177,290 +175,41 @@ const dbPath = path.isAbsolute(rawDbPath)
 
 console.log('Connecting to DB at:', dbPath);
 
-const options: Firebird.Options = {
-    host: dbConfig.host || '127.0.0.1',
-    port: dbConfig.port || 3050,
-    database: dbPath,
-    user: dbConfig.user || 'sysdba',
-    password: dbConfig.password || 'masterkey',
-    lowercase_keys: true,
-    role: '',
-    pageSize: 4096
-};
+const provider: DbProvider = createDbProvider({
+    dbConfig,
+    firebirdConfig: config.firebird,
+    firebirdDatabasePath: dbPath,
+});
 
-// Also support connecting to the file directly if we used Embedded, 
-// but node-firebird is a pure JS client (requires server) or uses native bindings?
-// 'node-firebird' is a pure JS implementation of the wire protocol. It NEEDS a running Firebird server.
-// It cannot open FDB files directly without a server process listening on a port.
-
-// This means the Python script or a service MUST be running.
-// We will assume server is running on localhost:3050.
-
-// Connection pooling: maintain a single persistent connection
-let persistentConnection: Firebird.Database | null = null;
-let connectionPromise: Promise<Firebird.Database> | null = null;
-
-export async function connectDB(): Promise<Firebird.Database> {
-    console.log('[DB] Attempting to attach to Firebird...');
-    return new Promise((resolve, reject) => {
-        Firebird.attach(options, (err, db) => {
-            if (err) {
-                console.error('[DB] Firebird attach failed:', err);
-                return reject(err);
-            }
-            console.log('[DB] Firebird attach successful');
-            resolve(db);
-        });
-    });
+export async function connectDB(): Promise<unknown> {
+    return provider.connect();
 }
 
-/**
- * Get or create a persistent database connection.
- * Implements connection pooling by reusing a single connection.
- * Includes a timeout to prevent indefinite hangs when Firebird is unreachable.
- */
-async function getConnection(): Promise<Firebird.Database> {
-    // If we have a working connection, return it
-    if (persistentConnection) {
-        return persistentConnection;
-    }
-
-    // If a connection is already being established, wait for it
-    if (connectionPromise) {
-        return connectionPromise;
-    }
-
-    const CONNECTION_TIMEOUT_MS = 10000; // 10 seconds
-
-    // Create a new connection with timeout
-    connectionPromise = new Promise<Firebird.Database>((resolve, reject) => {
-        // Pre-check: verify port is open before attempting attach
-        const port = options.port || 3050;
-        const host = options.host || '127.0.0.1';
-
-        console.log(`[DB] Attempting persistent connection to ${host}:${port}...`);
-
-        // Timeout guard — node-firebird has no built-in timeout
-        const timeout = setTimeout(() => {
-            connectionPromise = null;
-            persistentConnection = null;
-            reject(new Error(`Connection timeout after ${CONNECTION_TIMEOUT_MS / 1000}s — is Firebird running on ${host}:${port}?`));
-        }, CONNECTION_TIMEOUT_MS);
-
-        Firebird.attach(options, (err, db) => {
-            clearTimeout(timeout);
-            connectionPromise = null;
-
-            if (err) {
-                console.error('[DB] Failed to establish persistent connection:', err);
-                persistentConnection = null;
-                return reject(err);
-            }
-
-            console.log('[DB] Persistent connection established');
-            persistentConnection = db;
-            resolve(db);
-        });
-    });
-
-    return connectionPromise;
-}
-
-/**
- * Close the persistent database connection.
- */
 export function closeConnection(): void {
-    if (persistentConnection) {
-        persistentConnection.detach((err) => {
-            if (err) {
-                console.error('[DB] Error closing connection:', err);
-            } else {
-                console.log('[DB] Connection closed');
-            }
-            persistentConnection = null;
-        });
-    }
+    void provider.close();
 }
 
-// Check if Firebird port is open
-function isPortOpen(port: number, host: string = '127.0.0.1'): Promise<boolean> {
-    return new Promise((resolve) => {
-        const socket = new net.Socket();
-        socket.setTimeout(2000); // 2s timeout
-        socket.on('connect', () => {
-            socket.destroy();
-            resolve(true);
-        });
-        socket.on('timeout', () => {
-            socket.destroy();
-            resolve(false);
-        });
-        socket.on('error', () => {
-            socket.destroy();
-            resolve(false);
-        });
-        socket.connect(port, host);
-    });
-}
-
-// Ensure Firebird is running
 export async function ensureFirebirdRunning(): Promise<boolean> {
-    const port = dbConfig.port || 3050; // Use configured port or default
-    const host = dbConfig.host || '127.0.0.1';
-
-    console.log(`[DB] Checking if Firebird is running on ${host}:${port}...`);
-    const isOpen = await isPortOpen(port, host);
-
-    if (isOpen) {
-        console.log('[DB] Firebird is already running.');
-        return true;
-    }
-
-    console.log('[DB] Firebird port is closed. Attempting to start server...');
-    const firebirdPath = config.firebird?.path;
-
-    if (!firebirdPath) {
-        console.error('[DB] Firebird path not configured in config.json (firebird.path). Cannot auto-start.');
-        return false;
-    }
-
-    const binPath = path.join(firebirdPath, 'firebird.exe');
-
-    if (!fs.existsSync(binPath)) {
-        console.error(`[DB] Firebird executable not found at: ${binPath}`);
-        return false;
-    }
-
-    return new Promise((resolve) => {
-        console.log(`[DB] Spawning Firebird process: ${binPath} -a -p ${port}`);
-        // We use spawn to start it detached so it keeps running
-        const child = spawn(binPath, ['-a', '-p', String(port)], {
-            detached: true,
-            stdio: 'ignore', // Ignore stdio to allow it to run independently
-            windowsHide: true // Hide the window
-        });
-
-        child.unref(); // Allow the parent to exit without waiting for the child
-
-        // Now we need to wait for the port to open
-        console.log('[DB] Waiting for Firebird to be ready...');
-
-        let attempts = 0;
-        const maxAttempts = 20; // 20 * 500ms = 10s timeout
-
-        const checkInterval = setInterval(async () => {
-            attempts++;
-            const ready = await isPortOpen(port, host);
-            if (ready) {
-                clearInterval(checkInterval);
-                console.log('[DB] Firebird started successfully!');
-                resolve(true);
-            } else if (attempts >= maxAttempts) {
-                clearInterval(checkInterval);
-                console.error('[DB] Timeout waiting for Firebird to start.');
-                resolve(false);
-            }
-        }, 500);
-    });
+    return provider.verifyStartup();
 }
 
 export async function checkConnection(): Promise<boolean> {
-    try {
-        await query('SELECT 1 FROM RDB$DATABASE');
-        return true;
-    } catch (e) {
-        console.error('[DB] Check connection failed:', e);
-        return false;
-    }
+    return provider.checkConnection();
 }
 
-// Simple query queue to avoid concurrent operations on a single Firebird connection,
-// which has been observed to trigger internal driver errors in node-firebird.
-let queryChain: Promise<unknown> = Promise.resolve();
-
-async function executeQuery<T = unknown>(sql: string, params: (string | number | null)[] = []): Promise<T[]> {
-    try {
-        const db = await getConnection();
-
-        return await new Promise<T[]>((resolve, reject) => {
-            db.query(sql, params, (err, result) => {
-                if (err) {
-                    // Connection may be stale, reset it
-                    persistentConnection = null;
-                    return reject(err);
-                }
-
-                resolve(result as T[]);
-            });
-        });
-    } catch (err) {
-        console.error('[DB] Query failed:', err);
-        throw err;
-    }
-}
-
-export async function query<T = unknown>(sql: string, params: (string | number | null)[] = []): Promise<T[]> {
-    const run = () => executeQuery<T>(sql, params);
-
-    // Schedule this query to run after all previous queries complete,
-    // regardless of whether they succeeded or failed.
-    const p = queryChain.then(run, run);
-
-    // Advance the chain, but swallow individual query results/errors
-    // so that one failing query doesn't block the entire queue.
-    queryChain = p.then(
-        () => undefined,
-        () => undefined
-    );
-
-    return p;
+export async function query<T = unknown>(sql: string, params: QueryParam[] = []): Promise<T[]> {
+    return provider.query<T>(sql, params);
 }
 
 export async function runTransaction<T>(
-    callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: (string | number | null)[]) => Promise<R[]>) => Promise<T>,
+    callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
     isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED
 ): Promise<T> {
-    try {
-        const db = await getConnection();
-
-        return new Promise((resolve, reject) => {
-            db.transaction(isolation, async (err, transaction) => {
-                if (err) {
-                    // Connection may be stale, reset it
-                    persistentConnection = null;
-                    return reject(err);
-                }
-
-                const txQuery = <R = unknown>(sql: string, params: (string | number | null)[] = []): Promise<R[]> => {
-                    return new Promise((qResolve, qReject) => {
-                        transaction.query(sql, params, (qErr, result) => {
-                            if (qErr) return qReject(qErr);
-                            qResolve(result as R[]);
-                        });
-                    });
-                };
-
-                try {
-                    const result = await callback(transaction, txQuery);
-                    transaction.commit((commitErr) => {
-                        if (commitErr) {
-                            persistentConnection = null;
-                            return reject(commitErr);
-                        }
-                        resolve(result);
-                    });
-                } catch (cbErr) {
-                    transaction.rollback((rollbackErr) => {
-                        if (rollbackErr) console.error('[DB] Rollback error:', rollbackErr);
-                        reject(cbErr);
-                    });
-                }
-            });
-        });
-    } catch (err) {
-        console.error('[DB] Transaction failed:', err);
-        throw err;
+    if (provider instanceof FirebirdProvider) {
+        return provider.runTransaction(callback, isolation);
     }
+
+    throw new Error('runTransaction is currently only supported by the Firebird provider.');
 }
 
 function pushFolderFilter(

--- a/electron/db/provider.ts
+++ b/electron/db/provider.ts
@@ -5,16 +5,14 @@ import net from 'net';
 import path from 'path';
 
 export type QueryParam = string | number | null;
+export type TxQuery = <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>;
 
 export interface DbProvider {
     readonly type: 'firebird' | 'postgres';
     connect(): Promise<unknown>;
     close(): Promise<void>;
     query<T = unknown>(sql: string, params?: QueryParam[]): Promise<T[]>;
-    runTransaction<T>(
-        callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
-        isolation?: Firebird.Isolation,
-    ): Promise<T>;
+    runTransaction<T>(callback: (txQuery: TxQuery) => Promise<T>): Promise<T>;
     checkConnection(): Promise<boolean>;
     verifyStartup(): Promise<boolean>;
 }
@@ -154,11 +152,9 @@ export class FirebirdProvider implements DbProvider {
         });
     }
 
-    async runTransaction<T>(
-        callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
-        isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED,
-    ): Promise<T> {
+    async runTransaction<T>(callback: (txQuery: TxQuery) => Promise<T>): Promise<T> {
         const db = await this.getConnection();
+        const isolation = Firebird.ISOLATION_READ_COMMITTED;
 
         return new Promise((resolve, reject) => {
             db.transaction(isolation, async (err, transaction) => {
@@ -167,7 +163,7 @@ export class FirebirdProvider implements DbProvider {
                     return reject(err);
                 }
 
-                const txQuery = <R = unknown>(sql: string, params: QueryParam[] = []): Promise<R[]> => {
+                const txQuery: TxQuery = <R = unknown>(sql: string, params: QueryParam[] = []): Promise<R[]> => {
                     return new Promise((qResolve, qReject) => {
                         transaction.query(sql, params, (qErr, result) => {
                             if (qErr) return qReject(qErr);
@@ -177,7 +173,7 @@ export class FirebirdProvider implements DbProvider {
                 };
 
                 try {
-                    const result = await callback(transaction, txQuery);
+                    const result = await callback(txQuery);
                     transaction.commit((commitErr) => {
                         if (commitErr) {
                             this.persistentConnection = null;
@@ -288,14 +284,27 @@ type PgRow = Record<string, unknown>;
 
 interface PgPoolLike {
     query<T extends PgRow = PgRow>(sql: string, params?: QueryParam[]): Promise<{ rows: T[] }>;
+    connect(): Promise<PgPoolClientLike>;
     end(): Promise<void>;
 }
+
+interface PgPoolClientLike {
+    query<T extends PgRow = PgRow>(sql: string, params?: QueryParam[]): Promise<{ rows: T[] }>;
+    release(): void;
+}
+
+interface PgModuleLike {
+    Pool: new (config: PostgresConfig) => PgPoolLike;
+}
+
+const runtimeImport = new Function('moduleName', 'return import(moduleName)') as (moduleName: string) => Promise<unknown>;
 
 export class PostgresProvider implements DbProvider {
     readonly type = 'postgres' as const;
 
     private readonly poolConfig: PostgresConfig;
     private pool: PgPoolLike | null = null;
+    private poolPromise: Promise<PgPoolLike> | null = null;
 
     constructor(poolConfig: PostgresConfig = {}) {
         this.poolConfig = poolConfig;
@@ -317,11 +326,26 @@ export class PostgresProvider implements DbProvider {
         return result.rows as T[];
     }
 
-    async runTransaction<T>(
-        _callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
-        _isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED,
-    ): Promise<T> {
-        throw new Error('runTransaction is currently only supported by the Firebird provider.');
+    async runTransaction<T>(callback: (txQuery: TxQuery) => Promise<T>): Promise<T> {
+        const pool = await this.getPool();
+        const client = await pool.connect();
+
+        const txQuery: TxQuery = async <R = unknown>(sql: string, params: QueryParam[] = []): Promise<R[]> => {
+            const result = await client.query<R & PgRow>(sql, params);
+            return result.rows as R[];
+        };
+
+        try {
+            await client.query('BEGIN');
+            const result = await callback(txQuery);
+            await client.query('COMMIT');
+            return result;
+        } catch (e) {
+            await client.query('ROLLBACK');
+            throw e;
+        } finally {
+            client.release();
+        }
     }
 
     async checkConnection(): Promise<boolean> {
@@ -343,20 +367,34 @@ export class PostgresProvider implements DbProvider {
             return this.pool;
         }
 
-        const pg = require('pg') as { Pool: new (config: PostgresConfig) => PgPoolLike };
-        this.pool = new pg.Pool({
-            host: this.poolConfig.host || '127.0.0.1',
-            port: this.poolConfig.port || 5432,
-            user: this.poolConfig.user,
-            password: this.poolConfig.password,
-            database: this.poolConfig.database,
-            max: this.poolConfig.max,
-            idleTimeoutMillis: this.poolConfig.idleTimeoutMillis,
-            connectionTimeoutMillis: this.poolConfig.connectionTimeoutMillis,
-            ssl: this.poolConfig.ssl,
-        });
+        if (this.poolPromise) {
+            return this.poolPromise;
+        }
 
-        return this.pool;
+        this.poolPromise = (async () => {
+            try {
+                const pg = (await runtimeImport('pg')) as PgModuleLike;
+                this.pool = new pg.Pool({
+                    host: this.poolConfig.host || '127.0.0.1',
+                    port: this.poolConfig.port || 5432,
+                    user: this.poolConfig.user,
+                    password: this.poolConfig.password,
+                    database: this.poolConfig.database,
+                    max: this.poolConfig.max,
+                    idleTimeoutMillis: this.poolConfig.idleTimeoutMillis,
+                    connectionTimeoutMillis: this.poolConfig.connectionTimeoutMillis,
+                    ssl: this.poolConfig.ssl,
+                });
+                return this.pool;
+            } catch (error) {
+                const cause = error instanceof Error ? error.message : String(error);
+                throw new Error(`[DB] Failed to load "pg". Install it with "npm i pg" to use Postgres provider. Cause: ${cause}`);
+            } finally {
+                this.poolPromise = null;
+            }
+        })();
+
+        return this.poolPromise;
     }
 }
 
@@ -377,8 +415,11 @@ export function createDbProvider(config: {
     const provider = config.dbConfig.provider?.toLowerCase();
 
     if (provider === 'postgres' || provider === 'postgresql') {
+        if (!config.dbConfig.postgres) {
+            throw new Error('[DB] database.postgres config is required when provider is "postgres".');
+        }
         console.log('[DB] Using Postgres provider');
-        return new PostgresProvider(config.dbConfig.postgres || config.dbConfig);
+        return new PostgresProvider(config.dbConfig.postgres);
     }
 
     console.log('[DB] Using Firebird provider');

--- a/electron/db/provider.ts
+++ b/electron/db/provider.ts
@@ -1,0 +1,375 @@
+import Firebird from 'node-firebird';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import net from 'net';
+import path from 'path';
+
+export type QueryParam = string | number | null;
+
+export interface DbProvider {
+    readonly type: 'firebird' | 'postgres';
+    connect(): Promise<unknown>;
+    close(): Promise<void>;
+    query<T = unknown>(sql: string, params?: QueryParam[]): Promise<T[]>;
+    checkConnection(): Promise<boolean>;
+    verifyStartup(): Promise<boolean>;
+}
+
+interface FirebirdRuntimeConfig {
+    host?: string;
+    port?: number;
+    user?: string;
+    password?: string;
+    path?: string;
+}
+
+interface FirebirdBootConfig {
+    path?: string;
+}
+
+export class FirebirdProvider implements DbProvider {
+    readonly type = 'firebird' as const;
+
+    private readonly options: Firebird.Options;
+    private readonly firebirdConfig: FirebirdBootConfig;
+    private persistentConnection: Firebird.Database | null = null;
+    private connectionPromise: Promise<Firebird.Database> | null = null;
+    private queryChain: Promise<unknown> = Promise.resolve();
+
+    constructor(dbConfig: FirebirdRuntimeConfig, databasePath: string, firebirdConfig: FirebirdBootConfig = {}) {
+        this.options = {
+            host: dbConfig.host || '127.0.0.1',
+            port: dbConfig.port || 3050,
+            database: databasePath,
+            user: dbConfig.user || 'sysdba',
+            password: dbConfig.password || 'masterkey',
+            lowercase_keys: true,
+            role: '',
+            pageSize: 4096,
+        };
+        this.firebirdConfig = firebirdConfig;
+    }
+
+    async connect(): Promise<Firebird.Database> {
+        return this.getConnection();
+    }
+
+    async close(): Promise<void> {
+        if (!this.persistentConnection) return;
+
+        const db = this.persistentConnection;
+        this.persistentConnection = null;
+
+        await new Promise<void>((resolve) => {
+            db.detach((err) => {
+                if (err) {
+                    console.error('[DB] Error closing Firebird connection:', err);
+                } else {
+                    console.log('[DB] Firebird connection closed');
+                }
+                resolve();
+            });
+        });
+    }
+
+    async query<T = unknown>(sql: string, params: QueryParam[] = []): Promise<T[]> {
+        const run = () => this.executeQuery<T>(sql, params);
+
+        const p = this.queryChain.then(run, run);
+        this.queryChain = p.then(
+            () => undefined,
+            () => undefined,
+        );
+
+        return p;
+    }
+
+    async checkConnection(): Promise<boolean> {
+        try {
+            await this.query('SELECT 1 FROM RDB$DATABASE');
+            return true;
+        } catch (e) {
+            console.error('[DB] Firebird check connection failed:', e);
+            return false;
+        }
+    }
+
+    async verifyStartup(): Promise<boolean> {
+        const port = this.options.port || 3050;
+        const host = this.options.host || '127.0.0.1';
+
+        console.log(`[DB] Checking if Firebird is running on ${host}:${port}...`);
+        const isOpen = await this.isPortOpen(port, host);
+
+        if (isOpen) {
+            console.log('[DB] Firebird is already running.');
+            return true;
+        }
+
+        console.log('[DB] Firebird port is closed. Attempting to start server...');
+        const firebirdPath = this.firebirdConfig.path;
+
+        if (!firebirdPath) {
+            console.error('[DB] Firebird path not configured in config.json (firebird.path). Cannot auto-start.');
+            return false;
+        }
+
+        const binPath = path.join(firebirdPath, 'firebird.exe');
+
+        if (!fs.existsSync(binPath)) {
+            console.error(`[DB] Firebird executable not found at: ${binPath}`);
+            return false;
+        }
+
+        return new Promise((resolve) => {
+            console.log(`[DB] Spawning Firebird process: ${binPath} -a -p ${port}`);
+            const child = spawn(binPath, ['-a', '-p', String(port)], {
+                detached: true,
+                stdio: 'ignore',
+                windowsHide: true,
+            });
+            child.unref();
+
+            console.log('[DB] Waiting for Firebird to be ready...');
+            let attempts = 0;
+            const maxAttempts = 20;
+
+            const checkInterval = setInterval(async () => {
+                attempts++;
+                const ready = await this.isPortOpen(port, host);
+                if (ready) {
+                    clearInterval(checkInterval);
+                    console.log('[DB] Firebird started successfully!');
+                    resolve(true);
+                } else if (attempts >= maxAttempts) {
+                    clearInterval(checkInterval);
+                    console.error('[DB] Timeout waiting for Firebird to start.');
+                    resolve(false);
+                }
+            }, 500);
+        });
+    }
+
+    async runTransaction<T>(
+        callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
+        isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED,
+    ): Promise<T> {
+        const db = await this.getConnection();
+
+        return new Promise((resolve, reject) => {
+            db.transaction(isolation, async (err, transaction) => {
+                if (err) {
+                    this.persistentConnection = null;
+                    return reject(err);
+                }
+
+                const txQuery = <R = unknown>(sql: string, params: QueryParam[] = []): Promise<R[]> => {
+                    return new Promise((qResolve, qReject) => {
+                        transaction.query(sql, params, (qErr, result) => {
+                            if (qErr) return qReject(qErr);
+                            qResolve(result as R[]);
+                        });
+                    });
+                };
+
+                try {
+                    const result = await callback(transaction, txQuery);
+                    transaction.commit((commitErr) => {
+                        if (commitErr) {
+                            this.persistentConnection = null;
+                            return reject(commitErr);
+                        }
+                        resolve(result);
+                    });
+                } catch (cbErr) {
+                    transaction.rollback((rollbackErr) => {
+                        if (rollbackErr) console.error('[DB] Firebird rollback error:', rollbackErr);
+                        reject(cbErr);
+                    });
+                }
+            });
+        });
+    }
+
+    private async executeQuery<T = unknown>(sql: string, params: QueryParam[] = []): Promise<T[]> {
+        const db = await this.getConnection();
+
+        return new Promise<T[]>((resolve, reject) => {
+            db.query(sql, params, (err, result) => {
+                if (err) {
+                    this.persistentConnection = null;
+                    return reject(err);
+                }
+                resolve(result as T[]);
+            });
+        });
+    }
+
+    private async getConnection(): Promise<Firebird.Database> {
+        if (this.persistentConnection) {
+            return this.persistentConnection;
+        }
+
+        if (this.connectionPromise) {
+            return this.connectionPromise;
+        }
+
+        const CONNECTION_TIMEOUT_MS = 10000;
+
+        this.connectionPromise = new Promise<Firebird.Database>((resolve, reject) => {
+            const port = this.options.port || 3050;
+            const host = this.options.host || '127.0.0.1';
+
+            console.log(`[DB] Attempting persistent Firebird connection to ${host}:${port}...`);
+
+            const timeout = setTimeout(() => {
+                this.connectionPromise = null;
+                this.persistentConnection = null;
+                reject(new Error(`Connection timeout after ${CONNECTION_TIMEOUT_MS / 1000}s — is Firebird running on ${host}:${port}?`));
+            }, CONNECTION_TIMEOUT_MS);
+
+            Firebird.attach(this.options, (err, db) => {
+                clearTimeout(timeout);
+                this.connectionPromise = null;
+
+                if (err) {
+                    console.error('[DB] Failed to establish persistent Firebird connection:', err);
+                    this.persistentConnection = null;
+                    return reject(err);
+                }
+
+                console.log('[DB] Persistent Firebird connection established');
+                this.persistentConnection = db;
+                resolve(db);
+            });
+        });
+
+        return this.connectionPromise;
+    }
+
+    private async isPortOpen(port: number, host: string = '127.0.0.1'): Promise<boolean> {
+        return new Promise((resolve) => {
+            const socket = new net.Socket();
+            socket.setTimeout(2000);
+            socket.on('connect', () => {
+                socket.destroy();
+                resolve(true);
+            });
+            socket.on('timeout', () => {
+                socket.destroy();
+                resolve(false);
+            });
+            socket.on('error', () => {
+                socket.destroy();
+                resolve(false);
+            });
+            socket.connect(port, host);
+        });
+    }
+}
+
+interface PostgresConfig {
+    host?: string;
+    port?: number;
+    user?: string;
+    password?: string;
+    database?: string;
+    max?: number;
+    idleTimeoutMillis?: number;
+    connectionTimeoutMillis?: number;
+    ssl?: boolean | Record<string, unknown>;
+}
+
+type PgRow = Record<string, unknown>;
+
+interface PgPoolLike {
+    query<T extends PgRow = PgRow>(sql: string, params?: QueryParam[]): Promise<{ rows: T[] }>;
+    end(): Promise<void>;
+}
+
+export class PostgresProvider implements DbProvider {
+    readonly type = 'postgres' as const;
+
+    private readonly poolConfig: PostgresConfig;
+    private pool: PgPoolLike | null = null;
+
+    constructor(poolConfig: PostgresConfig = {}) {
+        this.poolConfig = poolConfig;
+    }
+
+    async connect(): Promise<PgPoolLike> {
+        return this.getPool();
+    }
+
+    async close(): Promise<void> {
+        if (!this.pool) return;
+        await this.pool.end();
+        this.pool = null;
+    }
+
+    async query<T = unknown>(sql: string, params: QueryParam[] = []): Promise<T[]> {
+        const pool = await this.getPool();
+        const result = await pool.query<T & PgRow>(sql, params);
+        return result.rows as T[];
+    }
+
+    async checkConnection(): Promise<boolean> {
+        try {
+            await this.query('SELECT 1');
+            return true;
+        } catch (e) {
+            console.error('[DB] Postgres check connection failed:', e);
+            return false;
+        }
+    }
+
+    async verifyStartup(): Promise<boolean> {
+        return this.checkConnection();
+    }
+
+    private async getPool(): Promise<PgPoolLike> {
+        if (this.pool) {
+            return this.pool;
+        }
+
+        const pg = require('pg') as { Pool: new (config: PostgresConfig) => PgPoolLike };
+        this.pool = new pg.Pool({
+            host: this.poolConfig.host || '127.0.0.1',
+            port: this.poolConfig.port || 5432,
+            user: this.poolConfig.user,
+            password: this.poolConfig.password,
+            database: this.poolConfig.database,
+            max: this.poolConfig.max,
+            idleTimeoutMillis: this.poolConfig.idleTimeoutMillis,
+            connectionTimeoutMillis: this.poolConfig.connectionTimeoutMillis,
+            ssl: this.poolConfig.ssl,
+        });
+
+        return this.pool;
+    }
+}
+
+interface ProviderFactoryConfig {
+    provider?: string;
+    postgres?: PostgresConfig;
+    host?: string;
+    port?: number;
+    user?: string;
+    password?: string;
+}
+
+export function createDbProvider(config: {
+    dbConfig: ProviderFactoryConfig;
+    firebirdConfig?: FirebirdBootConfig;
+    firebirdDatabasePath: string;
+}): DbProvider {
+    const provider = config.dbConfig.provider?.toLowerCase();
+
+    if (provider === 'postgres' || provider === 'postgresql') {
+        console.log('[DB] Using Postgres provider');
+        return new PostgresProvider(config.dbConfig.postgres || config.dbConfig);
+    }
+
+    console.log('[DB] Using Firebird provider');
+    return new FirebirdProvider(config.dbConfig, config.firebirdDatabasePath, config.firebirdConfig);
+}

--- a/electron/db/provider.ts
+++ b/electron/db/provider.ts
@@ -11,6 +11,10 @@ export interface DbProvider {
     connect(): Promise<unknown>;
     close(): Promise<void>;
     query<T = unknown>(sql: string, params?: QueryParam[]): Promise<T[]>;
+    runTransaction<T>(
+        callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
+        isolation?: Firebird.Isolation,
+    ): Promise<T>;
     checkConnection(): Promise<boolean>;
     verifyStartup(): Promise<boolean>;
 }
@@ -311,6 +315,13 @@ export class PostgresProvider implements DbProvider {
         const pool = await this.getPool();
         const result = await pool.query<T & PgRow>(sql, params);
         return result.rows as T[];
+    }
+
+    async runTransaction<T>(
+        _callback: (tx: Firebird.Transaction, txQuery: <R = unknown>(sql: string, params?: QueryParam[]) => Promise<R[]>) => Promise<T>,
+        _isolation: Firebird.Isolation = Firebird.ISOLATION_READ_COMMITTED,
+    ): Promise<T> {
+        throw new Error('runTransaction is currently only supported by the Firebird provider.');
     }
 
     async checkConnection(): Promise<boolean> {


### PR DESCRIPTION
### Motivation
- Introduce a pluggable DB abstraction to support multiple backends (Firebird and Postgres) and make a future Firebird→Postgres migration safer. 
- Encapsulate connection lifecycle, query execution, health checks and startup logic so DB-specific details are isolated and easier to maintain. 
- Preserve existing IPC-facing APIs and return shapes so existing consumers are not broken by the refactor. 

### Description
- Added a new provider abstraction and factory in `electron/db/provider.ts` exposing `DbProvider` with `connect/close/query/checkConnection/verifyStartup` and a `createDbProvider` factory. 
- Moved the existing Firebird connection, serialized query queue, startup auto-start and transaction support into `FirebirdProvider` so previous behavior is preserved behind the interface. 
- Added a `PostgresProvider` scaffold that uses `pg` `Pool` with config-driven options (host/port/user/password/database/pool/timeouts/ssl) and basic health checks, selected only when `database.provider` is set to `postgres`. 
- Updated `electron/db.ts` to instantiate the provider and route exported functions (`connectDB`, `closeConnection`, `ensureFirebirdRunning`, `checkConnection`, `query`, `runTransaction`, and all existing image/folder/keyword helpers) through the provider layer while preserving existing IPC function names and return shapes. 
- Kept Firebird as the default provider and added `database.provider` and `database.postgres` scaffolding to `config.example.json` so switching backends requires explicit opt-in. 

### Testing
- Ran TypeScript compilation with `npx tsc -p electron/tsconfig.json`, which completed successfully. 
- No other automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21e06d344832395d0ed4da643c30d)