### PR TITLE
Add strict database engine config typing and Postgres validation

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
     "database": {
         "engine": "firebird",
+        "provider": "firebird",
         "host": "127.0.0.1",
         "port": 3050,
         "user": "sysdba",

--- a/config.example.json
+++ b/config.example.json
@@ -1,10 +1,28 @@
 {
     "database": {
+        "engine": "firebird",
         "host": "127.0.0.1",
         "port": 3050,
         "user": "sysdba",
         "password": "masterkey",
-        "path": "../image-scoring-backend/SCORING_HISTORY.FDB"
+        "path": "../image-scoring-backend/SCORING_HISTORY.FDB",
+        "postgres": {
+            "host": "127.0.0.1",
+            "port": 5432,
+            "database": "image_scoring",
+            "user": "postgres",
+            "password": "postgres",
+            "ssl": {
+                "enabled": false,
+                "rejectUnauthorized": true
+            },
+            "pool": {
+                "min": 0,
+                "max": 10,
+                "idleTimeoutMillis": 30000,
+                "connectionTimeoutMillis": 10000
+            }
+        }
     },
     "dev": {
         "url": "http://localhost:5173"

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -28,6 +28,10 @@ function toEngine(value: unknown): DatabaseEngine {
     return value === 'postgres' ? 'postgres' : 'firebird';
 }
 
+function getEngineFromDatabaseConfig(rawDatabase: JsonRecord): DatabaseEngine {
+    return toEngine(rawDatabase.engine ?? rawDatabase.provider);
+}
+
 function normalizePostgresSsl(value: unknown): boolean | PostgresSslConfig | undefined {
     if (typeof value === 'boolean') return value;
     if (!isRecord(value)) return undefined;
@@ -88,11 +92,12 @@ export function validatePostgresConfig(databaseConfig: JsonRecord): PostgresConf
 export function normalizeAppConfig(rawConfig: unknown): AppConfig {
     const cfg = isRecord(rawConfig) ? { ...rawConfig } : {};
     const rawDatabase = isRecord(cfg.database) ? { ...cfg.database } : {};
-    const engine = toEngine(rawDatabase.engine);
+    const engine = getEngineFromDatabaseConfig(rawDatabase);
 
     if (engine === 'firebird') {
         const normalizedDatabase: FirebirdDatabaseConfig = {
             engine: 'firebird',
+            provider: 'firebird',
             host: asString(rawDatabase.host) || '127.0.0.1',
             port: asNumber(rawDatabase.port) || 3050,
             user: asString(rawDatabase.user) || 'sysdba',
@@ -111,6 +116,7 @@ export function normalizeAppConfig(rawConfig: unknown): AppConfig {
     } else {
         const normalizedDatabase: PostgresDatabaseConfig = {
             engine: 'postgres',
+            provider: 'postgres',
             postgres: validatePostgresConfig(rawDatabase),
         };
         return {

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import type {
     AppConfig,
     DatabaseEngine,
+    FirebirdDatabaseConfig,
+    PostgresDatabaseConfig,
     PostgresPoolConfig,
     PostgresSslConfig,
     PostgresConfig,
@@ -87,25 +89,35 @@ export function normalizeAppConfig(rawConfig: unknown): AppConfig {
     const rawDatabase = isRecord(cfg.database) ? { ...cfg.database } : {};
     const engine = toEngine(rawDatabase.engine);
 
-    const normalizedDatabase: AppConfig['database'] = {
-        ...rawDatabase,
-        engine,
-    };
-
     if (engine === 'firebird') {
-        normalizedDatabase.host = asString(rawDatabase.host) || '127.0.0.1';
-        normalizedDatabase.port = asNumber(rawDatabase.port) || 3050;
-        normalizedDatabase.user = asString(rawDatabase.user) || 'sysdba';
-        normalizedDatabase.password = asString(rawDatabase.password) || 'masterkey';
-        normalizedDatabase.path = asString(rawDatabase.path) || rawDatabase.path as string | undefined;
-    } else {
-        normalizedDatabase.postgres = validatePostgresConfig(rawDatabase);
-    }
+        const normalizedDatabase: FirebirdDatabaseConfig = {
+            ...rawDatabase,
+            engine: 'firebird',
+            host: asString(rawDatabase.host) || '127.0.0.1',
+            port: asNumber(rawDatabase.port) || 3050,
+            user: asString(rawDatabase.user) || 'sysdba',
+            password: asString(rawDatabase.password) || 'masterkey',
+        };
 
-    return {
-        ...cfg,
-        database: normalizedDatabase,
-    };
+        const dbPath = asString(rawDatabase.path);
+        if (dbPath) {
+            normalizedDatabase.path = dbPath;
+        }
+
+        return {
+            ...cfg,
+            database: normalizedDatabase,
+        };
+    } else {
+        const normalizedDatabase: PostgresDatabaseConfig = {
+            engine: 'postgres',
+            postgres: validatePostgresConfig(rawDatabase),
+        };
+        return {
+            ...cfg,
+            database: normalizedDatabase,
+        };
+    }
 }
 
 export function loadAppConfig(configPath: string): AppConfig {

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -71,17 +71,18 @@ export function validatePostgresConfig(databaseConfig: JsonRecord): PostgresConf
     if (!port || port <= 0) throw new Error('database.postgres.port must be a positive number.');
     if (!database) throw new Error('database.postgres.database is required.');
     if (!user) throw new Error('database.postgres.user is required.');
-    if (!password) throw new Error('database.postgres.password is required.');
-
-    return {
+    const normalized: PostgresConfig = {
         host,
         port,
         database,
         user,
-        password,
         ssl: normalizePostgresSsl(postgres.ssl),
         pool: normalizePostgresPool(postgres.pool),
     };
+    if (password) {
+        normalized.password = password;
+    }
+    return normalized;
 }
 
 export function normalizeAppConfig(rawConfig: unknown): AppConfig {
@@ -91,7 +92,6 @@ export function normalizeAppConfig(rawConfig: unknown): AppConfig {
 
     if (engine === 'firebird') {
         const normalizedDatabase: FirebirdDatabaseConfig = {
-            ...rawDatabase,
             engine: 'firebird',
             host: asString(rawDatabase.host) || '127.0.0.1',
             port: asNumber(rawDatabase.port) || 3050,
@@ -137,6 +137,7 @@ export function getConfigPath(fromDirname: string): string {
 }
 
 export function deepMergeConfig<T extends JsonRecord>(target: T, source: JsonRecord): T {
+    // Arrays are intentionally replaced as atomic values rather than merged index-by-index.
     const out = { ...target } as JsonRecord;
     for (const [key, value] of Object.entries(source)) {
         if (isRecord(value) && isRecord(out[key])) {

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import path from 'path';
+import type {
+    AppConfig,
+    DatabaseEngine,
+    PostgresPoolConfig,
+    PostgresSslConfig,
+    PostgresConfig,
+} from './types';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function toEngine(value: unknown): DatabaseEngine {
+    return value === 'postgres' ? 'postgres' : 'firebird';
+}
+
+function normalizePostgresSsl(value: unknown): boolean | PostgresSslConfig | undefined {
+    if (typeof value === 'boolean') return value;
+    if (!isRecord(value)) return undefined;
+
+    const out: PostgresSslConfig = {};
+    if (typeof value.enabled === 'boolean') out.enabled = value.enabled;
+    if (typeof value.rejectUnauthorized === 'boolean') out.rejectUnauthorized = value.rejectUnauthorized;
+    if (typeof value.ca === 'string') out.ca = value.ca;
+    if (typeof value.cert === 'string') out.cert = value.cert;
+    if (typeof value.key === 'string') out.key = value.key;
+    return out;
+}
+
+function normalizePostgresPool(value: unknown): PostgresPoolConfig | undefined {
+    if (!isRecord(value)) return undefined;
+    const out: PostgresPoolConfig = {};
+    const min = asNumber(value.min);
+    const max = asNumber(value.max);
+    const idleTimeoutMillis = asNumber(value.idleTimeoutMillis);
+    const connectionTimeoutMillis = asNumber(value.connectionTimeoutMillis);
+    if (min !== undefined) out.min = min;
+    if (max !== undefined) out.max = max;
+    if (idleTimeoutMillis !== undefined) out.idleTimeoutMillis = idleTimeoutMillis;
+    if (connectionTimeoutMillis !== undefined) out.connectionTimeoutMillis = connectionTimeoutMillis;
+    return out;
+}
+
+export function validatePostgresConfig(databaseConfig: JsonRecord): PostgresConfig {
+    const postgres = isRecord(databaseConfig.postgres) ? databaseConfig.postgres : null;
+    if (!postgres) {
+        throw new Error('database.postgres is required when database.engine is "postgres".');
+    }
+
+    const host = asString(postgres.host);
+    const port = asNumber(postgres.port);
+    const database = asString(postgres.database);
+    const user = asString(postgres.user);
+    const password = asString(postgres.password);
+
+    if (!host) throw new Error('database.postgres.host is required.');
+    if (!port || port <= 0) throw new Error('database.postgres.port must be a positive number.');
+    if (!database) throw new Error('database.postgres.database is required.');
+    if (!user) throw new Error('database.postgres.user is required.');
+    if (!password) throw new Error('database.postgres.password is required.');
+
+    return {
+        host,
+        port,
+        database,
+        user,
+        password,
+        ssl: normalizePostgresSsl(postgres.ssl),
+        pool: normalizePostgresPool(postgres.pool),
+    };
+}
+
+export function normalizeAppConfig(rawConfig: unknown): AppConfig {
+    const cfg = isRecord(rawConfig) ? { ...rawConfig } : {};
+    const rawDatabase = isRecord(cfg.database) ? { ...cfg.database } : {};
+    const engine = toEngine(rawDatabase.engine);
+
+    const normalizedDatabase: AppConfig['database'] = {
+        ...rawDatabase,
+        engine,
+    };
+
+    if (engine === 'firebird') {
+        normalizedDatabase.host = asString(rawDatabase.host) || '127.0.0.1';
+        normalizedDatabase.port = asNumber(rawDatabase.port) || 3050;
+        normalizedDatabase.user = asString(rawDatabase.user) || 'sysdba';
+        normalizedDatabase.password = asString(rawDatabase.password) || 'masterkey';
+        normalizedDatabase.path = asString(rawDatabase.path) || rawDatabase.path as string | undefined;
+    } else {
+        normalizedDatabase.postgres = validatePostgresConfig(rawDatabase);
+    }
+
+    return {
+        ...cfg,
+        database: normalizedDatabase,
+    };
+}
+
+export function loadAppConfig(configPath: string): AppConfig {
+    try {
+        if (fs.existsSync(configPath)) {
+            const parsed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+            return normalizeAppConfig(parsed);
+        }
+    } catch (e) {
+        console.error('Failed to load config.json:', e);
+    }
+    return normalizeAppConfig({});
+}
+
+export function getConfigPath(fromDirname: string): string {
+    return path.resolve(path.join(fromDirname, '../config.json'));
+}
+
+export function deepMergeConfig<T extends JsonRecord>(target: T, source: JsonRecord): T {
+    const out = { ...target } as JsonRecord;
+    for (const [key, value] of Object.entries(source)) {
+        if (isRecord(value) && isRecord(out[key])) {
+            out[key] = deepMergeConfig(out[key] as JsonRecord, value);
+        } else {
+            out[key] = value;
+        }
+    }
+    return out as T;
+}

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -164,36 +164,43 @@ function resolveSiblingDbPath(filename: string): string {
 // Add test detection — tests must NEVER use production DB
 const isTestEnv = process.env.NODE_ENV === 'test' || process.env.VITEST;
 
-// Database options
-// If path is relative in config, it's relative to the project root (one level up from dist-electron)
-let rawDbPath: string;
+let cachedFirebirdOptions: Firebird.Options | null = null;
 
-if (isTestEnv) {
-    // Force test DB only — matches image-scoring/scripts/setup_test_db.py (scoring_history_test.fdb)
-    rawDbPath = resolveSiblingDbPath('scoring_history_test.fdb');
-    console.warn('[DB] Test environment detected! Using test DB only: scoring_history_test.fdb');
-} else {
-    rawDbPath = firebirdDbConfig.path
-        ? firebirdDbConfig.path
-        : resolveSiblingDbPath('SCORING_HISTORY.FDB');
+function getFirebirdOptions(): Firebird.Options {
+    assertFirebirdEngine();
+    if (cachedFirebirdOptions) {
+        return cachedFirebirdOptions;
+    }
+
+    let rawDbPath: string;
+    if (isTestEnv) {
+        // Force test DB only — matches image-scoring/scripts/setup_test_db.py (scoring_history_test.fdb)
+        rawDbPath = resolveSiblingDbPath('scoring_history_test.fdb');
+        console.warn('[DB] Test environment detected! Using test DB only: scoring_history_test.fdb');
+    } else {
+        rawDbPath = firebirdDbConfig.path
+            ? firebirdDbConfig.path
+            : resolveSiblingDbPath('SCORING_HISTORY.FDB');
+    }
+
+    const dbPath = path.isAbsolute(rawDbPath)
+        ? rawDbPath
+        : path.resolve(projectRoot, rawDbPath);
+
+    console.log('Connecting to DB at:', dbPath);
+
+    cachedFirebirdOptions = {
+        host: firebirdDbConfig.host || '127.0.0.1',
+        port: firebirdDbConfig.port || 3050,
+        database: dbPath,
+        user: firebirdDbConfig.user || 'sysdba',
+        password: firebirdDbConfig.password || 'masterkey',
+        lowercase_keys: true,
+        role: '',
+        pageSize: 4096
+    };
+    return cachedFirebirdOptions;
 }
-
-const dbPath = path.isAbsolute(rawDbPath)
-    ? rawDbPath
-    : path.resolve(projectRoot, rawDbPath);
-
-console.log('Connecting to DB at:', dbPath);
-
-const options: Firebird.Options = {
-    host: firebirdDbConfig.host || '127.0.0.1',
-    port: firebirdDbConfig.port || 3050,
-    database: dbPath,
-    user: firebirdDbConfig.user || 'sysdba',
-    password: firebirdDbConfig.password || 'masterkey',
-    lowercase_keys: true,
-    role: '',
-    pageSize: 4096
-};
 
 // Also support connecting to the file directly if we used Embedded, 
 // but node-firebird is a pure JS client (requires server) or uses native bindings?
@@ -208,7 +215,7 @@ let persistentConnection: Firebird.Database | null = null;
 let connectionPromise: Promise<Firebird.Database> | null = null;
 
 export async function connectDB(): Promise<Firebird.Database> {
-    assertFirebirdEngine();
+    const options = getFirebirdOptions();
     console.log('[DB] Attempting to attach to Firebird...');
     return new Promise((resolve, reject) => {
         Firebird.attach(options, (err, db) => {
@@ -228,7 +235,7 @@ export async function connectDB(): Promise<Firebird.Database> {
  * Includes a timeout to prevent indefinite hangs when Firebird is unreachable.
  */
 async function getConnection(): Promise<Firebird.Database> {
-    assertFirebirdEngine();
+    const options = getFirebirdOptions();
     // If we have a working connection, return it
     if (persistentConnection) {
         return persistentConnection;
@@ -317,8 +324,9 @@ export async function ensureFirebirdRunning(): Promise<boolean> {
     if (dbEngine === 'postgres') {
         return true;
     }
-    const port = firebirdDbConfig.port || 3050; // Use configured port or default
-    const host = firebirdDbConfig.host || '127.0.0.1';
+    const options = getFirebirdOptions();
+    const port = options.port || 3050; // Use configured port or default
+    const host = options.host || '127.0.0.1';
 
     console.log(`[DB] Checking if Firebird is running on ${host}:${port}...`);
     const isOpen = await isPortOpen(port, host);

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -16,6 +16,7 @@ function loadConfig(): AppConfig {
 const config = loadConfig();
 const dbConfig = config.database || {};
 const projectRoot = path.resolve(__dirname, '..');
+// Support both `database.engine` and legacy/alternate `database.provider` during branch convergence.
 const dbEngine = dbConfig.engine || dbConfig.provider || 'firebird';
 const firebirdDbConfig: FirebirdDatabaseConfig = dbEngine === 'firebird'
     ? dbConfig as FirebirdDatabaseConfig
@@ -23,7 +24,7 @@ const firebirdDbConfig: FirebirdDatabaseConfig = dbEngine === 'firebird'
 
 function assertFirebirdEngine(): void {
     if (dbEngine === 'postgres') {
-        throw new Error('database.engine is set to "postgres", but electron/db.ts currently supports Firebird only.');
+        throw new Error('database.engine/provider is set to "postgres", but electron/db.ts currently supports Firebird only.');
     }
 }
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -16,7 +16,7 @@ function loadConfig(): AppConfig {
 const config = loadConfig();
 const dbConfig = config.database || {};
 const projectRoot = path.resolve(__dirname, '..');
-const dbEngine = dbConfig.engine || 'firebird';
+const dbEngine = dbConfig.engine || dbConfig.provider || 'firebird';
 const firebirdDbConfig: FirebirdDatabaseConfig = dbEngine === 'firebird'
     ? dbConfig as FirebirdDatabaseConfig
     : {};

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -4,23 +4,24 @@ import fs from 'fs';
 
 import { spawn } from 'child_process';
 import net from 'net';
+import { getConfigPath, loadAppConfig } from './config';
+import type { AppConfig } from './types';
 
 // Load configuration
-function loadConfig() {
-    const configPath = path.resolve(path.join(__dirname, '../config.json'));
-    try {
-        if (fs.existsSync(configPath)) {
-            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        }
-    } catch (e) {
-        console.error('Failed to load config.json:', e);
-    }
-    return {};
+function loadConfig(): AppConfig {
+    return loadAppConfig(getConfigPath(__dirname));
 }
 
 const config = loadConfig();
 const dbConfig = config.database || {};
 const projectRoot = path.resolve(__dirname, '..');
+const dbEngine = dbConfig.engine || 'firebird';
+
+function assertFirebirdEngine(): void {
+    if (dbEngine === 'postgres') {
+        throw new Error('database.engine is set to "postgres", but electron/db.ts currently supports Firebird only.');
+    }
+}
 
 /** Optional config: see config.example.json → paths */
 interface PathsConfig {
@@ -168,7 +169,9 @@ if (isTestEnv) {
     rawDbPath = resolveSiblingDbPath('scoring_history_test.fdb');
     console.warn('[DB] Test environment detected! Using test DB only: scoring_history_test.fdb');
 } else {
-    rawDbPath = dbConfig.path || resolveSiblingDbPath('SCORING_HISTORY.FDB');
+    rawDbPath = (dbConfig.path && dbEngine === 'firebird')
+        ? dbConfig.path
+        : resolveSiblingDbPath('SCORING_HISTORY.FDB');
 }
 
 const dbPath = path.isAbsolute(rawDbPath)
@@ -201,6 +204,7 @@ let persistentConnection: Firebird.Database | null = null;
 let connectionPromise: Promise<Firebird.Database> | null = null;
 
 export async function connectDB(): Promise<Firebird.Database> {
+    assertFirebirdEngine();
     console.log('[DB] Attempting to attach to Firebird...');
     return new Promise((resolve, reject) => {
         Firebird.attach(options, (err, db) => {
@@ -220,6 +224,7 @@ export async function connectDB(): Promise<Firebird.Database> {
  * Includes a timeout to prevent indefinite hangs when Firebird is unreachable.
  */
 async function getConnection(): Promise<Firebird.Database> {
+    assertFirebirdEngine();
     // If we have a working connection, return it
     if (persistentConnection) {
         return persistentConnection;
@@ -305,6 +310,7 @@ function isPortOpen(port: number, host: string = '127.0.0.1'): Promise<boolean> 
 
 // Ensure Firebird is running
 export async function ensureFirebirdRunning(): Promise<boolean> {
+    assertFirebirdEngine();
     const port = dbConfig.port || 3050; // Use configured port or default
     const host = dbConfig.host || '127.0.0.1';
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -6,6 +6,7 @@ import { spawn } from 'child_process';
 import net from 'net';
 import { getConfigPath, loadAppConfig } from './config';
 import type { AppConfig } from './types';
+import type { FirebirdDatabaseConfig } from './types';
 
 // Load configuration
 function loadConfig(): AppConfig {
@@ -16,6 +17,9 @@ const config = loadConfig();
 const dbConfig = config.database || {};
 const projectRoot = path.resolve(__dirname, '..');
 const dbEngine = dbConfig.engine || 'firebird';
+const firebirdDbConfig: FirebirdDatabaseConfig = dbEngine === 'firebird'
+    ? dbConfig as FirebirdDatabaseConfig
+    : {};
 
 function assertFirebirdEngine(): void {
     if (dbEngine === 'postgres') {
@@ -169,8 +173,8 @@ if (isTestEnv) {
     rawDbPath = resolveSiblingDbPath('scoring_history_test.fdb');
     console.warn('[DB] Test environment detected! Using test DB only: scoring_history_test.fdb');
 } else {
-    rawDbPath = (dbConfig.path && dbEngine === 'firebird')
-        ? dbConfig.path
+    rawDbPath = firebirdDbConfig.path
+        ? firebirdDbConfig.path
         : resolveSiblingDbPath('SCORING_HISTORY.FDB');
 }
 
@@ -181,11 +185,11 @@ const dbPath = path.isAbsolute(rawDbPath)
 console.log('Connecting to DB at:', dbPath);
 
 const options: Firebird.Options = {
-    host: dbConfig.host || '127.0.0.1',
-    port: dbConfig.port || 3050,
+    host: firebirdDbConfig.host || '127.0.0.1',
+    port: firebirdDbConfig.port || 3050,
     database: dbPath,
-    user: dbConfig.user || 'sysdba',
-    password: dbConfig.password || 'masterkey',
+    user: firebirdDbConfig.user || 'sysdba',
+    password: firebirdDbConfig.password || 'masterkey',
     lowercase_keys: true,
     role: '',
     pageSize: 4096
@@ -310,9 +314,11 @@ function isPortOpen(port: number, host: string = '127.0.0.1'): Promise<boolean> 
 
 // Ensure Firebird is running
 export async function ensureFirebirdRunning(): Promise<boolean> {
-    assertFirebirdEngine();
-    const port = dbConfig.port || 3050; // Use configured port or default
-    const host = dbConfig.host || '127.0.0.1';
+    if (dbEngine === 'postgres') {
+        return true;
+    }
+    const port = firebirdDbConfig.port || 3050; // Use configured port or default
+    const host = firebirdDbConfig.host || '127.0.0.1';
 
     console.log(`[DB] Checking if Firebird is running on ${host}:${port}...`);
     const isOpen = await isPortOpen(port, host);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,7 @@ import { ExifTool } from 'exiftool-vendored';
 import { ApiService } from './apiService';
 import { ExportImageContext } from './types';
 import { SessionLogManager } from './sessionLogManager';
+import { deepMergeConfig, getConfigPath, loadAppConfig, normalizeAppConfig } from './config';
 
 const exiftool = new ExifTool({ maxProcs: 2 });
 
@@ -308,15 +309,8 @@ protocol.registerSchemesAsPrivileged([
 
 // Load configuration
 function loadConfig() {
-    const configPath = path.resolve(path.join(__dirname, '../config.json'));
-    try {
-        if (fs.existsSync(configPath)) {
-            return JSON.parse(fs.readFileSync(configPath, 'utf8'));
-        }
-    } catch (e) {
-        console.error('Failed to load config.json:', e);
-    }
-    return {};
+    const configPath = getConfigPath(__dirname);
+    return loadAppConfig(configPath);
 }
 
 const config = loadConfig();
@@ -832,7 +826,7 @@ app.whenReady().then(async () => {
     }));
 
     ipcMain.handle('system:save-config', wrapIpcHandler(async (_, updates) => {
-        const configPath = path.resolve(path.join(__dirname, '../config.json'));
+        const configPath = getConfigPath(__dirname);
         let currentConfig: Record<string, unknown> = {};
         try {
             if (fs.existsSync(configPath)) {
@@ -842,14 +836,11 @@ app.whenReady().then(async () => {
             console.error('[Main] Error reading config for save:', e);
         }
 
-        // Deep merge updates
-        const newConfig = { ...currentConfig };
-        if (updates.selection) {
-            newConfig.selection = {
-                ...(newConfig.selection || {}),
-                ...updates.selection
-            };
-        }
+        const updatesObj = typeof updates === 'object' && updates !== null
+            ? updates as Record<string, unknown>
+            : {};
+        const mergedConfig = deepMergeConfig(currentConfig, updatesObj);
+        const newConfig = normalizeAppConfig(mergedConfig);
 
         try {
             await fs.promises.writeFile(configPath, JSON.stringify(newConfig, null, 2));

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -97,13 +97,42 @@ export interface DuplicateResponse {
     message?: string;
 }
 
+export type DatabaseEngine = 'firebird' | 'postgres';
+
+export interface PostgresSslConfig {
+    enabled?: boolean;
+    rejectUnauthorized?: boolean;
+    ca?: string;
+    cert?: string;
+    key?: string;
+}
+
+export interface PostgresPoolConfig {
+    min?: number;
+    max?: number;
+    idleTimeoutMillis?: number;
+    connectionTimeoutMillis?: number;
+}
+
+export interface PostgresConfig {
+    host: string;
+    port: number;
+    database: string;
+    user: string;
+    password: string;
+    ssl?: boolean | PostgresSslConfig;
+    pool?: PostgresPoolConfig;
+}
+
 export interface AppConfig {
     database?: {
+        engine?: DatabaseEngine;
         host?: string;
         port?: number;
         path?: string;
         user?: string;
         password?: string;
+        postgres?: Partial<PostgresConfig>;
     };
     dev?: {
         url?: string;

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -124,16 +124,24 @@ export interface PostgresConfig {
     pool?: PostgresPoolConfig;
 }
 
+export interface FirebirdDatabaseConfig {
+    engine?: 'firebird';
+    host?: string;
+    port?: number;
+    path?: string;
+    user?: string;
+    password?: string;
+}
+
+export interface PostgresDatabaseConfig {
+    engine: 'postgres';
+    postgres: PostgresConfig;
+}
+
+export type DatabaseConfig = FirebirdDatabaseConfig | PostgresDatabaseConfig;
+
 export interface AppConfig {
-    database?: {
-        engine?: DatabaseEngine;
-        host?: string;
-        port?: number;
-        path?: string;
-        user?: string;
-        password?: string;
-        postgres?: Partial<PostgresConfig>;
-    };
+    database?: DatabaseConfig;
     dev?: {
         url?: string;
     };

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -126,6 +126,8 @@ export interface PostgresConfig {
 
 export interface FirebirdDatabaseConfig {
     engine?: 'firebird';
+    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
+    provider?: 'firebird';
     host?: string;
     port?: number;
     path?: string;
@@ -135,6 +137,8 @@ export interface FirebirdDatabaseConfig {
 
 export interface PostgresDatabaseConfig {
     engine: 'postgres';
+    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
+    provider?: 'postgres';
     postgres: PostgresConfig;
 }
 

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -119,7 +119,7 @@ export interface PostgresConfig {
     port: number;
     database: string;
     user: string;
-    password: string;
+    password?: string;
     ssl?: boolean | PostgresSslConfig;
     pool?: PostgresPoolConfig;
 }

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -110,7 +110,7 @@ interface PostgresConfig {
 }
 
 interface FirebirdDatabaseConfig {
-    engine?: 'firebird';
+    engine?: Extract<DatabaseEngine, 'firebird'>;
     /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
     provider?: 'firebird';
     host?: string;
@@ -121,7 +121,7 @@ interface FirebirdDatabaseConfig {
 }
 
 interface PostgresDatabaseConfig {
-    engine: 'postgres';
+    engine: Extract<DatabaseEngine, 'postgres'>;
     /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
     provider?: 'postgres';
     postgres: PostgresConfig;

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -81,13 +81,42 @@ interface DuplicateResponse {
     message?: string;
 }
 
+type DatabaseEngine = 'firebird' | 'postgres';
+
+interface PostgresSslConfig {
+    enabled?: boolean;
+    rejectUnauthorized?: boolean;
+    ca?: string;
+    cert?: string;
+    key?: string;
+}
+
+interface PostgresPoolConfig {
+    min?: number;
+    max?: number;
+    idleTimeoutMillis?: number;
+    connectionTimeoutMillis?: number;
+}
+
+interface PostgresConfig {
+    host: string;
+    port: number;
+    database: string;
+    user: string;
+    password: string;
+    ssl?: boolean | PostgresSslConfig;
+    pool?: PostgresPoolConfig;
+}
+
 interface AppConfig {
     database?: {
+        engine?: DatabaseEngine;
         host?: string;
         port?: number;
         path?: string;
         user?: string;
         password?: string;
+        postgres?: Partial<PostgresConfig>;
     };
     dev?: {
         url?: string;
@@ -101,6 +130,11 @@ interface AppConfig {
         path?: string;
     };
     selection?: Record<string, unknown>;
+    paths?: {
+        thumbnail_path_remap?: Array<{ from: string; to: string }>;
+        remap_legacy_image_scoring_thumbnails?: boolean;
+        thumbnail_base_dir?: string;
+    };
     [key: string]: unknown;
 }
 

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -108,16 +108,24 @@ interface PostgresConfig {
     pool?: PostgresPoolConfig;
 }
 
+interface FirebirdDatabaseConfig {
+    engine?: 'firebird';
+    host?: string;
+    port?: number;
+    path?: string;
+    user?: string;
+    password?: string;
+}
+
+interface PostgresDatabaseConfig {
+    engine: 'postgres';
+    postgres: PostgresConfig;
+}
+
+type DatabaseConfig = FirebirdDatabaseConfig | PostgresDatabaseConfig;
+
 interface AppConfig {
-    database?: {
-        engine?: DatabaseEngine;
-        host?: string;
-        port?: number;
-        path?: string;
-        user?: string;
-        password?: string;
-        postgres?: Partial<PostgresConfig>;
-    };
+    database?: DatabaseConfig;
     dev?: {
         url?: string;
     };

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -111,6 +111,8 @@ interface PostgresConfig {
 
 interface FirebirdDatabaseConfig {
     engine?: 'firebird';
+    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
+    provider?: 'firebird';
     host?: string;
     port?: number;
     path?: string;
@@ -120,6 +122,8 @@ interface FirebirdDatabaseConfig {
 
 interface PostgresDatabaseConfig {
     engine: 'postgres';
+    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
+    provider?: 'postgres';
     postgres: PostgresConfig;
 }
 

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -82,6 +82,7 @@ interface DuplicateResponse {
 }
 
 type DatabaseEngine = 'firebird' | 'postgres';
+// NOTE: Keep the database config types below in sync with electron/types.ts.
 
 interface PostgresSslConfig {
     enabled?: boolean;
@@ -103,7 +104,7 @@ interface PostgresConfig {
     port: number;
     database: string;
     user: string;
-    password: string;
+    password?: string;
     ssl?: boolean | PostgresSslConfig;
     pool?: PostgresPoolConfig;
 }


### PR DESCRIPTION
### Motivation
- Introduce an explicit `database.engine` option so the app can support multiple DB backends (`firebird|postgres`) while keeping backward compatibility with existing Firebird-only configs.
- Provide a strongly-typed, shared config shape between renderer and main process so config reads/writes and IPC remain type-safe.
- Validate Postgres connection settings when `engine` is `postgres` to fail fast and avoid runtime surprises.

### Description
- Extend `config.example.json` to include `database.engine` (default `firebird`) and a nested `database.postgres` object with `host`, `port`, `database`, `user`, `password` and optional `ssl`/`pool` fields.
- Add `electron/config.ts` with `normalizeAppConfig`, `loadAppConfig`, `validatePostgresConfig`, `deepMergeConfig`, and `getConfigPath` to normalize, validate and merge configs with safe defaults.
- Update shared types in `electron/types.ts` and runtime declaration `src/electron.d.ts` to add `DatabaseEngine`, `PostgresConfig`, `PostgresSslConfig`, and `PostgresPoolConfig` so renderer and main share the same strict shape.
- Update `electron/main.ts` to use `getConfigPath`/`loadAppConfig` and to deep-merge and normalize incoming `save-config` updates before writing.
- Update `electron/db.ts` to load the normalized config and to guard Firebird-specific code paths with an `assertFirebirdEngine()` check and to preserve Firebird defaults for backward compatibility.

### Testing
- Ran TypeScript compile for the electron project with `npx tsc -p electron/tsconfig.json --noEmit` which succeeded.
- Ran the targeted unit test with `npm run -s test:run -- electron/apiUrlResolver.test.ts` which passed (`1 file, 7 tests`).
- Ran repository lint with `npm run -s lint`, which surfaced existing repo-wide lint errors unrelated to these changes (lint run did not pass due to preexisting issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c21e08a11083239512b1e93655267a)