### PR TITLE
docs: mark job_progress subscription complete across TODO mirrors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Project-level task list. Items marked `[Python]`, `[Gradio]`, or `[DB]` involve 
 
 > **Source of truth & update order:** This file is the canonical task ledger (owner: Electron maintainers). Update this file first, then sync `docs/planning/01-roadmap-todo.md`, then `docs/integration/TODO.md`, and finally `docs/features/planned/embeddings/TODO.md`.
 
-Last evaluated: 2026-03-16.
+Last evaluated: 2026-03-28.
 
 | Marker | Use when |
 |--------|----------|
@@ -98,7 +98,7 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 ## Python / Backend Integration [Python] [Gradio]
 
 - [ ] [Gradio] Gradio Integration: Enhance IPC/WebSocket bridge for real-time AI updates — coordinate bidirectional command channel protocol with Python backend (see `image-scoring/TODO.md` → Clustering & Embeddings)
-- [ ] [Gradio] Subscribe to `job_progress` for live progress bar (optional; currently job_started/job_completed only)
+- [x] [Gradio] Subscribe to `job_progress` for live progress bar (`src/hooks/useGalleryWebSocket.ts` `subscribe('job_progress', ...)`, rendered via `src/components/Layout/JobProgressBar.tsx`, state in `src/store/useJobProgressStore.ts`)
 - [ ] [Python] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
 - [ ] [Python] Sync `electron/apiTypes.ts` when backend API contract changes
 - [ ] Document `config.api.url` / `config.api.port` override in user-facing docs

--- a/docs/features/planned/embeddings/TODO.md
+++ b/docs/features/planned/embeddings/TODO.md
@@ -10,7 +10,7 @@ This document tracks the remaining work for the embedding-based features in the 
 - [x] **"More Like This" Search**: Similarity search drawer and context menu.
 
 ## 🟡 In Progress
-- [ ] **Gradio Integration**: Enhance IPC/WebSocket bridge for real-time AI updates (job progress subscription still pending).
+- [ ] **Gradio Integration**: Enhance IPC/WebSocket bridge for real-time AI updates (`job_progress` subscription is complete in `src/hooks/useGalleryWebSocket.ts` via `subscribe('job_progress', ...)`, surfaced by `src/components/Layout/JobProgressBar.tsx` with state in `src/store/useJobProgressStore.ts`; focus remaining work on broader queue/log pipeline milestones).
 
 ## 🔴 Planned (Missing)
 ### Feature 3: Tag Propagation

--- a/docs/integration/TODO.md
+++ b/docs/integration/TODO.md
@@ -11,7 +11,7 @@ Tasks for Electron ↔ Python backend integration. See [Agent Coordination](http
 
 ## WebSocket
 
-- [ ] Subscribe to `job_progress` for live progress bar (optional; currently job_started/job_completed only)
+- [x] Subscribe to `job_progress` for live progress bar (`src/hooks/useGalleryWebSocket.ts` `subscribe('job_progress', ...)`, `src/components/Layout/JobProgressBar.tsx`, `src/store/useJobProgressStore.ts`)
 - [x] Ensure `image_updated` and `folder_updated` handlers refresh correct views
 
 ## Configuration

--- a/docs/planning/01-roadmap-todo.md
+++ b/docs/planning/01-roadmap-todo.md
@@ -1,6 +1,6 @@
 # TODO - Electron Image Scoring
 
-Consolidated list of unfinished work items. Last Updated: Mar 14, 2026.
+Consolidated list of unfinished work items. Last Updated: Mar 28, 2026.
 
 > **Source of truth & update order:** Secondary roadmap mirror (owner: planning/docs maintainers). Sync only after `TODO.md`, then reconcile this file before updating `docs/integration/TODO.md` and `docs/features/planned/embeddings/TODO.md`.
 
@@ -18,10 +18,10 @@ Use these rules for any count snapshots in this document:
 
 ### Compact Counting Example (from `P1 (High Priority)`)
 
-- Open items in this section: **5** (Gradio Pipeline + Embedding parent + 2 child items + request token; Vitest and handlers completed)
+- Open items in this section: **4** (Gradio Pipeline + Embedding parent + 2 child items; request token/Vitest/handlers complete)
 - Cross-repo items: **3** (Embedding parent + 2 children with `[Python]`)
-- Electron-only items: **2** (Gradio Pipeline, request token)
-- Check: `open (5) = cross-repo (3) + Electron-only (2)`
+- Electron-only items: **1** (Gradio Pipeline)
+- Check: `open (4) = cross-repo (3) + Electron-only (1)`
 
 ---
 
@@ -43,9 +43,10 @@ Use these rules for any count snapshots in this document:
 - [ ] **Embedding Feature Integration** [Python]:
     - [ ] Add "Find Similar" to context menu and details panel
     - [ ] Integrate "Duplicate Finder" into main navigation
-- [ ] Add explicit request token / in-flight guard to `useImages` for pagination races
+- [x] Add explicit request token / in-flight guard to `useImages` for pagination races
 - [x] Setup `Vitest` and basic test coverage for hooks/services
 - [x] Ensure `image_updated` and `folder_updated` handlers refresh correct views
+- [x] Subscribe to `job_progress` for live progress updates (`src/hooks/useGalleryWebSocket.ts` `subscribe('job_progress', ...)`, `src/components/Layout/JobProgressBar.tsx`, `src/store/useJobProgressStore.ts`)
 
 ## P2 (Medium Priority)
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate work by making the TODO/roadmap mirrors accurately reflect that the `job_progress` WebSocket subscription is implemented and where it lives.

### Description
- Updated `TODO.md` (source of truth) to mark `[Gradio] Subscribe to job_progress` complete, bump the evaluation date, and reference `src/hooks/useGalleryWebSocket.ts` (`subscribe('job_progress', ...)`), `src/components/Layout/JobProgressBar.tsx`, and `src/store/useJobProgressStore.ts`.
- Synced `docs/planning/01-roadmap-todo.md` to align the update date, compact counting math, and mark the related P1 items complete.
- Updated `docs/integration/TODO.md` to mark the WebSocket `job_progress` subscription complete and point to the implemented paths.
- Updated `docs/features/planned/embeddings/TODO.md` to note that `job_progress` subscription is complete while leaving broader Gradio integration work as in-progress.

### Testing
- Ran `git diff --check` which produced no issues.
- Committed the documentation changes with message `docs: mark job_progress subscription complete across TODO mirrors`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74c2dd8ec8323becc6cf2f3ae79f9)