### PR TITLE
Add outlier visualization/filtering to gallery workflow

### DIFF
--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -21,6 +21,7 @@ import { useGalleryNavigation } from './hooks/useGalleryNavigation';
 import { useStacksMode } from './hooks/useStacksMode';
 import { useImageOpener } from './hooks/useImageOpener';
 import { useGalleryWebSocket } from './hooks/useGalleryWebSocket';
+import { useOutlierMarkers } from './hooks/useOutlierMarkers';
 import breadcrumbStyles from './styles/breadcrumbs.module.css';
 import toggleStyles from './styles/toggle.module.css';
 
@@ -30,6 +31,7 @@ interface AppContentProps {
 
 function AppContent({ isConnected }: AppContentProps) {
   const [filters, setFilters] = useState<FilterState>({ minRating: 0, sortBy: 'score_general', order: 'DESC' });
+  const [outlierRefreshKey, setOutlierRefreshKey] = useState(0);
 
   const { folders, loading: foldersLoading, refresh: refreshFolders } = useFolders();
   const { keywords, loading: keywordsLoading, fetch: fetchKeywords } = useKeywords();
@@ -55,9 +57,20 @@ function AppContent({ isConnected }: AppContentProps) {
     // cleared by useStacksMode on folder change
   });
 
+  const queryFilters = useMemo(
+    () => ({
+      minRating: filters.minRating,
+      colorLabel: filters.colorLabel,
+      keyword: filters.keyword,
+      sortBy: filters.sortBy,
+      order: filters.order,
+    }),
+    [filters.minRating, filters.colorLabel, filters.keyword, filters.sortBy, filters.order],
+  );
+
   const imageFilters = useMemo(
-    () => subfolderIds ? { ...filters, folderIds: subfolderIds } : filters,
-    [filters, subfolderIds],
+    () => subfolderIds ? { ...queryFilters, folderIds: subfolderIds } : queryFilters,
+    [queryFilters, subfolderIds],
   );
 
   const {
@@ -97,6 +110,17 @@ function AppContent({ isConnected }: AppContentProps) {
     loadStackImages,
     stacksModeRef,
     activeStackIdRef,
+    onVisibleRefresh: () => setOutlierRefreshKey(v => v + 1),
+  });
+
+  const selectedFolderPath = currentFolder?.path;
+  const { outlierIds, outlierMetaById } = useOutlierMarkers({
+    enabled: !!filters.highlightOutliers,
+    folderPath: selectedFolderPath,
+    zThreshold: 2.5,
+    k: 10,
+    limit: 300,
+    refreshKey: outlierRefreshKey,
   });
 
   const handleNavigateToFolder = (folderId: number) => {
@@ -145,10 +169,16 @@ function AppContent({ isConnected }: AppContentProps) {
   };
 
   // Current display list and count
-  const currentImages = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
+  const baseCurrentImages = (stacksMode && !activeStackId) ? stacks : (activeStackId ? stackImages : images);
+  const currentImages = useMemo(() => {
+    if (!filters.onlyOutliers || !filters.highlightOutliers || stacksMode) {
+      return baseCurrentImages;
+    }
+    return baseCurrentImages.filter((img) => outlierIds.has(img.id));
+  }, [baseCurrentImages, filters.onlyOutliers, filters.highlightOutliers, outlierIds, stacksMode]);
   const currentTotal = stacksMode && !activeStackId
     ? stacksTotalCount
-    : (activeStackId ? (activeStackInfo?.imageCount || stackImages.length) : totalCount);
+    : (activeStackId ? (activeStackInfo?.imageCount || stackImages.length) : (filters.onlyOutliers && filters.highlightOutliers ? currentImages.length : totalCount));
 
   const isInitialGridLoading = stacksMode && !activeStackId
     ? (stacksLoading && stacks.length === 0)
@@ -404,6 +434,9 @@ function AppContent({ isConnected }: AppContentProps) {
                   onSelectStack={handleSelectStack}
                   onStackEndReached={loadMoreStacks}
                   activeStackId={activeStackId}
+                  highlightOutliers={!!filters.highlightOutliers && !stacksMode}
+                  outlierIds={outlierIds}
+                  outlierMetaById={outlierMetaById}
                 />
                 {openingImage && (
                   <ImageViewer

--- a/src/components/Gallery/GalleryGrid.module.css
+++ b/src/components/Gallery/GalleryGrid.module.css
@@ -143,6 +143,21 @@
   backdrop-filter: blur(4px);
 }
 
+.outlierBadge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: rgba(227, 71, 63, 0.92);
+  color: #fff;
+  font-size: 10px;
+  letter-spacing: 0.3px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.45);
+}
+
 /* Context menu */
 .contextMenu {
   position: fixed;

--- a/src/components/Gallery/GalleryGrid.outliers.test.tsx
+++ b/src/components/Gallery/GalleryGrid.outliers.test.tsx
@@ -25,12 +25,14 @@ describe('GalleryGrid outlier badge', () => {
         ]}
         highlightOutliers={true}
         outlierIds={new Set([101])}
-        outlierMetaById={new Map([[101, { zScore: 2.95, outlierScore: 1.33, neighborSummary: 'Nearest: #5 (82%)' }]])}
+        outlierMetaById={
+          new Map([[101, { zScore: 2.95, outlierScore: 1.33, neighborSummary: 'Nearest match (id 5, 82% similar)' }]])
+        }
       />,
     );
 
     const badge = screen.getByText('Outlier');
     expect(badge).toBeTruthy();
-    expect(badge.getAttribute('title')).toBe('Outlier • z=2.95 • Nearest: #5 (82%)');
+    expect(badge.getAttribute('title')).toBe('Outlier • z=2.95 • Nearest match (id 5, 82% similar)');
   });
 });

--- a/src/components/Gallery/GalleryGrid.outliers.test.tsx
+++ b/src/components/Gallery/GalleryGrid.outliers.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GalleryGrid } from './GalleryGrid';
+import type { ReactNode } from 'react';
+
+vi.mock('react-virtuoso', () => ({
+  VirtuosoGrid: ({ totalCount, itemContent }: { totalCount: number; itemContent: (index: number) => ReactNode }) => (
+    <div>{Array.from({ length: totalCount }, (_, i) => <div key={i}>{itemContent(i)}</div>)}</div>
+  ),
+}));
+
+describe('GalleryGrid outlier badge', () => {
+  it('renders outlier badge with tooltip metadata', () => {
+    render(
+      <GalleryGrid
+        images={[
+          {
+            id: 101,
+            file_path: '/img/a.jpg',
+            file_name: 'a.jpg',
+            score_general: 0.5,
+            rating: 3,
+            label: null,
+          },
+        ]}
+        highlightOutliers={true}
+        outlierIds={new Set([101])}
+        outlierMetaById={new Map([[101, { zScore: 2.95, outlierScore: 1.33, neighborSummary: 'Nearest: #5 (82%)' }]])}
+      />,
+    );
+
+    const badge = screen.getByText('Outlier');
+    expect(badge).toBeTruthy();
+    expect(badge.getAttribute('title')).toBe('Outlier • z=2.95 • Nearest: #5 (82%)');
+  });
+});

--- a/src/components/Gallery/GalleryGrid.tsx
+++ b/src/components/Gallery/GalleryGrid.tsx
@@ -47,6 +47,9 @@ interface GalleryGridProps {
     onSelectStack?: (stack: Image) => void;
     onStackEndReached?: () => void;
     activeStackId?: number | null;
+    highlightOutliers?: boolean;
+    outlierIds?: Set<number>;
+    outlierMetaById?: Map<number, { zScore: number; outlierScore: number; neighborSummary: string }>;
 }
 
 const ItemContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ style, children, className, ...props }, ref) => (
@@ -65,7 +68,7 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
     images, onSelect, onEndReached, subfolders, onSelectFolder,
     onNavigateToParent, viewerOpen = false, sortBy = 'score_general',
     stacksMode = false, stacks = [], onSelectStack, onStackEndReached,
-    activeStackId
+    activeStackId, highlightOutliers = false, outlierIds = new Set<number>(), outlierMetaById = new Map()
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -126,6 +129,11 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
 
     const renderImageCard = useCallback((img: Image, onClick: () => void) => {
         const labelColor = getLabelColor(img.label);
+        const isOutlier = highlightOutliers && outlierIds.has(img.id);
+        const outlierMeta = outlierMetaById.get(img.id);
+        const outlierTooltip = outlierMeta
+            ? `Outlier • z=${outlierMeta.zScore.toFixed(2)} • ${outlierMeta.neighborSummary}`
+            : 'Outlier';
 
         return (
             <div
@@ -141,6 +149,15 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                     <div className={styles.ratingOverlay}>
                         <span className={styles.ratingStars}>{'★'.repeat(img.rating)}</span>
                     </div>
+                    {isOutlier && (
+                        <div
+                            className={styles.outlierBadge}
+                            title={outlierTooltip}
+                            aria-label={outlierTooltip}
+                        >
+                            Outlier
+                        </div>
+                    )}
                 </div>
 
                 <div className={styles.cardMeta} style={{ borderTop: `2px solid ${labelColor}` }}>
@@ -153,7 +170,7 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                 </div>
             </div>
         );
-    }, [getScoreDisplay, getLabelColor]);
+    }, [getScoreDisplay, getLabelColor, highlightOutliers, outlierIds, outlierMetaById]);
 
     const renderStackCard = useCallback((stack: Image, onClick: () => void) => {
         const labelColor = getLabelColor(stack.label);

--- a/src/components/Gallery/GalleryGrid.tsx
+++ b/src/components/Gallery/GalleryGrid.tsx
@@ -52,6 +52,9 @@ interface GalleryGridProps {
     outlierMetaById?: Map<number, { zScore: number; outlierScore: number; neighborSummary: string }>;
 }
 
+const EMPTY_OUTLIER_IDS = new Set<number>();
+const EMPTY_OUTLIER_META = new Map<number, { zScore: number; outlierScore: number; neighborSummary: string }>();
+
 const ItemContainer = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ style, children, className, ...props }, ref) => (
     <div ref={ref} style={style} className={`${styles.listContainer} ${className || ''}`} {...props}>
         {children}
@@ -68,7 +71,7 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
     images, onSelect, onEndReached, subfolders, onSelectFolder,
     onNavigateToParent, viewerOpen = false, sortBy = 'score_general',
     stacksMode = false, stacks = [], onSelectStack, onStackEndReached,
-    activeStackId, highlightOutliers = false, outlierIds = new Set<number>(), outlierMetaById = new Map()
+    activeStackId, highlightOutliers = false, outlierIds = EMPTY_OUTLIER_IDS, outlierMetaById = EMPTY_OUTLIER_META
 }) => {
     const containerRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/Sidebar/FilterPanel.module.css
+++ b/src/components/Sidebar/FilterPanel.module.css
@@ -81,3 +81,57 @@
 .colorDotActive {
   border-color: white;
 }
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12px;
+  color: #ddd;
+}
+
+.toggle {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: #444;
+  border: 1px solid #666;
+  border-radius: 11px;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+  flex-shrink: 0;
+}
+
+.toggle:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: var(--focus-offset);
+}
+
+.toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.toggle[aria-checked="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.15s ease;
+  pointer-events: none;
+}
+
+.toggle[aria-checked="true"] .thumb {
+  transform: translateX(18px);
+}

--- a/src/components/Sidebar/FilterPanel.tsx
+++ b/src/components/Sidebar/FilterPanel.tsx
@@ -7,6 +7,8 @@ export interface FilterState {
     keyword?: string;
     sortBy?: string;
     order?: 'ASC' | 'DESC';
+    highlightOutliers?: boolean;
+    onlyOutliers?: boolean;
 }
 
 interface FilterPanelProps {
@@ -22,6 +24,19 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({ filters, onChange }) =
 
     const handleColorChange = (c?: string) => {
         onChange({ ...filters, colorLabel: c });
+    };
+
+    const handleToggleHighlightOutliers = () => {
+        const nextHighlight = !filters.highlightOutliers;
+        onChange({
+            ...filters,
+            highlightOutliers: nextHighlight,
+            onlyOutliers: nextHighlight ? filters.onlyOutliers : false,
+        });
+    };
+
+    const handleToggleOnlyOutliers = () => {
+        onChange({ ...filters, onlyOutliers: !filters.onlyOutliers });
     };
 
     return (
@@ -67,6 +82,35 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({ filters, onChange }) =
                             aria-label={tooltip}
                         />
                     ))}
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <div className={styles.sectionLabel}>Outliers</div>
+                <div className={styles.toggleRow}>
+                    <span>Highlight outliers</span>
+                    <button
+                        role="switch"
+                        aria-checked={!!filters.highlightOutliers}
+                        aria-label="Highlight outliers"
+                        className={styles.toggle}
+                        onClick={handleToggleHighlightOutliers}
+                    >
+                        <span className={styles.thumb} />
+                    </button>
+                </div>
+                <div className={styles.toggleRow}>
+                    <span style={{ opacity: filters.highlightOutliers ? 1 : 0.5 }}>Only outliers</span>
+                    <button
+                        role="switch"
+                        aria-checked={!!filters.onlyOutliers}
+                        aria-label="Only outliers"
+                        className={styles.toggle}
+                        onClick={handleToggleOnlyOutliers}
+                        disabled={!filters.highlightOutliers}
+                    >
+                        <span className={styles.thumb} />
+                    </button>
                 </div>
             </div>
         </div>

--- a/src/hooks/useGalleryWebSocket.ts
+++ b/src/hooks/useGalleryWebSocket.ts
@@ -39,6 +39,8 @@ export function useGalleryWebSocket({
   refreshFoldersRef.current = refreshFolders;
   const loadStackImagesRef = useRef(loadStackImages);
   loadStackImagesRef.current = loadStackImages;
+  const onVisibleRefreshRef = useRef(onVisibleRefresh);
+  onVisibleRefreshRef.current = onVisibleRefresh;
 
   useEffect(() => {
     type WebSocketClient = {
@@ -61,18 +63,18 @@ export function useGalleryWebSocket({
 
         if (activeStackIdRef.current !== null) {
           void loadStackImagesRef.current(activeStackIdRef.current);
-          onVisibleRefresh?.();
+          onVisibleRefreshRef.current?.();
           return;
         }
 
         if (stacksModeRef.current) {
           refreshStacksRef.current({ preserveItems: true });
-          onVisibleRefresh?.();
+          onVisibleRefreshRef.current?.();
           return;
         }
 
         refreshImagesRef.current({ preserveItems: true });
-        onVisibleRefresh?.();
+        onVisibleRefreshRef.current?.();
       }, 500);
     };
 
@@ -174,5 +176,5 @@ export function useGalleryWebSocket({
       if (folderRefreshTimer) clearTimeout(folderRefreshTimer);
       if (ws) ws.disconnect();
     };
-  }, [addNotification, onVisibleRefresh]);
+  }, [addNotification]);
 }

--- a/src/hooks/useGalleryWebSocket.ts
+++ b/src/hooks/useGalleryWebSocket.ts
@@ -10,6 +10,7 @@ interface UseGalleryWebSocketParams {
   loadStackImages: (stackId: number) => Promise<void>;
   stacksModeRef: React.MutableRefObject<boolean>;
   activeStackIdRef: React.MutableRefObject<number | null>;
+  onVisibleRefresh?: () => void;
 }
 
 /**
@@ -25,6 +26,7 @@ export function useGalleryWebSocket({
   loadStackImages,
   stacksModeRef,
   activeStackIdRef,
+  onVisibleRefresh,
 }: UseGalleryWebSocketParams) {
   const addNotification = useNotificationStore(state => state.addNotification);
 
@@ -59,15 +61,18 @@ export function useGalleryWebSocket({
 
         if (activeStackIdRef.current !== null) {
           void loadStackImagesRef.current(activeStackIdRef.current);
+          onVisibleRefresh?.();
           return;
         }
 
         if (stacksModeRef.current) {
           refreshStacksRef.current({ preserveItems: true });
+          onVisibleRefresh?.();
           return;
         }
 
         refreshImagesRef.current({ preserveItems: true });
+        onVisibleRefresh?.();
       }, 500);
     };
 
@@ -169,5 +174,5 @@ export function useGalleryWebSocket({
       if (folderRefreshTimer) clearTimeout(folderRefreshTimer);
       if (ws) ws.disconnect();
     };
-  }, [addNotification]);
+  }, [addNotification, onVisibleRefresh]);
 }

--- a/src/hooks/useOutlierMarkers.test.tsx
+++ b/src/hooks/useOutlierMarkers.test.tsx
@@ -34,6 +34,9 @@ describe('useOutlierMarkers', () => {
       expect(findOutliersMock).toHaveBeenCalledWith({ folderPath: '/photos', zThreshold: 2.5, k: 10, limit: 200 });
       expect(result.current.outlierIds.has(42)).toBe(true);
       expect(result.current.outlierMetaById.get(42)?.zScore).toBe(3.25);
+      expect(result.current.outlierMetaById.get(42)?.neighborSummary).toBe(
+        'Nearest match (id 7, 88% similar)',
+      );
     });
   });
 

--- a/src/hooks/useOutlierMarkers.test.tsx
+++ b/src/hooks/useOutlierMarkers.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useOutlierMarkers } from './useOutlierMarkers';
+
+const findOutliersMock = vi.fn();
+
+vi.mock('../bridge', () => ({
+  bridge: {
+    findOutliers: (...args: unknown[]) => findOutliersMock(...args),
+  },
+}));
+
+describe('useOutlierMarkers', () => {
+  beforeEach(() => {
+    findOutliersMock.mockReset();
+  });
+
+  it('fetches outliers when highlighting is enabled', async () => {
+    findOutliersMock.mockResolvedValue({
+      outliers: [
+        {
+          image_id: 42,
+          file_path: '/tmp/a.jpg',
+          outlier_score: 1.7,
+          z_score: 3.25,
+          nearest_neighbors: [{ image_id: 7, file_path: '/tmp/b.jpg', similarity: 0.88 }],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useOutlierMarkers({ enabled: true, folderPath: '/photos' }));
+
+    await waitFor(() => {
+      expect(findOutliersMock).toHaveBeenCalledWith({ folderPath: '/photos', zThreshold: 2.5, k: 10, limit: 200 });
+      expect(result.current.outlierIds.has(42)).toBe(true);
+      expect(result.current.outlierMetaById.get(42)?.zScore).toBe(3.25);
+    });
+  });
+
+  it('cleans up outlier state when folder changes', async () => {
+    findOutliersMock
+      .mockResolvedValueOnce({
+        outliers: [
+          {
+            image_id: 10,
+            file_path: '/f1/a.jpg',
+            outlier_score: 1.1,
+            z_score: 2.8,
+            nearest_neighbors: [],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ outliers: [] });
+
+    const { result, rerender } = renderHook(
+      ({ folderPath }) => useOutlierMarkers({ enabled: true, folderPath }),
+      { initialProps: { folderPath: '/folder-a' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.outlierIds.has(10)).toBe(true);
+    });
+
+    rerender({ folderPath: '/folder-b' });
+
+    expect(result.current.outlierIds.size).toBe(0);
+
+    await waitFor(() => {
+      expect(findOutliersMock).toHaveBeenLastCalledWith({ folderPath: '/folder-b', zThreshold: 2.5, k: 10, limit: 200 });
+    });
+  });
+});

--- a/src/hooks/useOutlierMarkers.ts
+++ b/src/hooks/useOutlierMarkers.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from 'react';
+import { bridge } from '../bridge';
+
+interface OutlierNeighbor {
+  image_id: number;
+  file_path: string;
+  similarity: number;
+}
+
+interface OutlierInfo {
+  image_id: number;
+  file_path: string;
+  outlier_score: number;
+  z_score: number;
+  nearest_neighbors: OutlierNeighbor[];
+}
+
+export interface OutlierMeta {
+  zScore: number;
+  outlierScore: number;
+  neighborSummary: string;
+}
+
+interface UseOutlierMarkersOptions {
+  enabled: boolean;
+  folderPath?: string;
+  zThreshold?: number;
+  k?: number;
+  limit?: number;
+  refreshKey?: number;
+}
+
+export function useOutlierMarkers({
+  enabled,
+  folderPath,
+  zThreshold = 2.5,
+  k = 10,
+  limit = 200,
+  refreshKey = 0,
+}: UseOutlierMarkersOptions) {
+  const [outliers, setOutliers] = useState<OutlierInfo[]>([]);
+
+  useEffect(() => {
+    if (!enabled || !folderPath) {
+      setOutliers([]);
+      return;
+    }
+
+    let isActive = true;
+    setOutliers([]);
+
+    bridge.findOutliers({ folderPath, zThreshold, k, limit })
+      .then((response) => {
+        if (!isActive) return;
+        setOutliers(response?.outliers || []);
+      })
+      .catch((error) => {
+        console.error('[useOutlierMarkers] Failed to fetch outliers', error);
+        if (!isActive) return;
+        setOutliers([]);
+      });
+
+    return () => {
+      isActive = false;
+    };
+  }, [enabled, folderPath, zThreshold, k, limit, refreshKey]);
+
+  const outlierIds = useMemo(() => new Set(outliers.map((item) => item.image_id)), [outliers]);
+
+  const outlierMetaById = useMemo(() => {
+    const byId = new Map<number, OutlierMeta>();
+    outliers.forEach((item) => {
+      const nearest = item.nearest_neighbors?.[0];
+      const neighborSummary = nearest
+        ? `Nearest: #${nearest.image_id} (${Math.round(nearest.similarity * 100)}%)`
+        : 'Nearest: none';
+      byId.set(item.image_id, {
+        zScore: item.z_score,
+        outlierScore: item.outlier_score,
+        neighborSummary,
+      });
+    });
+    return byId;
+  }, [outliers]);
+
+  return {
+    outlierIds,
+    outlierMetaById,
+  };
+}

--- a/src/hooks/useOutlierMarkers.ts
+++ b/src/hooks/useOutlierMarkers.ts
@@ -72,8 +72,8 @@ export function useOutlierMarkers({
     outliers.forEach((item) => {
       const nearest = item.nearest_neighbors?.[0];
       const neighborSummary = nearest
-        ? `Nearest: #${nearest.image_id} (${Math.round(nearest.similarity * 100)}%)`
-        : 'Nearest: none';
+        ? `Nearest match (id ${nearest.image_id}, ${Math.round(nearest.similarity * 100)}% similar)`
+        : 'Nearest match: none';
       byId.set(item.image_id, {
         zScore: item.z_score,
         outlierScore: item.outlier_score,


### PR DESCRIPTION
### Motivation
- Provide UI controls to highlight and optionally filter to visual outliers so users can spot anomalous images quickly.
- Fetch outlier metadata from the backend and surface quick explainability (z-score and nearest-neighbor summary) in the gallery overlay.
- Keep outlier markers synchronized with existing real-time refreshes so badges remain accurate after backend updates.

### Description
- Extended `FilterState` with `highlightOutliers` and `onlyOutliers` and added toggles to the sidebar in `FilterPanel` with appropriate enable/disable behavior and styles.  
- Added `useOutlierMarkers` hook that calls `bridge.findOutliers({ folderPath, zThreshold, k, limit })`, stores results, exposes a `Set` of `image_id`s and a meta `Map`, and clears state when disabled or folder changes.  
- Wired outlier fetching into `AppContent`: separated DB query filters from UI-only outlier flags, added `outlierRefreshKey` which is incremented from the existing websocket visible-refresh path (`useGalleryWebSocket`), applied optional "only outliers" filtering to the current image list, and passed `outlierIds`/`outlierMetaById` into `GalleryGrid`.  
- Updated `GalleryGrid` to accept outlier props and render a visible `Outlier` badge overlay with a tooltip showing `z_score` and a nearest-neighbor summary, and added corresponding CSS styles.  
- Added tests exercising fetch-on-toggle and cleanup behavior (`useOutlierMarkers.test.tsx`) and badge rendering with tooltip metadata (`GalleryGrid.outliers.test.tsx`).

### Testing
- Ran the new unit tests with `npm run test:run -- src/hooks/useOutlierMarkers.test.tsx src/components/Gallery/GalleryGrid.outliers.test.tsx`, and both test files passed.  
- Ran type-checking with `npx tsc --noEmit`, which completed successfully.  
- Tests added: `src/hooks/useOutlierMarkers.test.tsx` (fetch + cleanup) and `src/components/Gallery/GalleryGrid.outliers.test.tsx` (badge rendering).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74c3078d88323ad787f3bad039a5c)