### PR TITLE
Add embeddings map scaffold and Smart Cover settings plumbing

### DIFF
--- a/docs/features/planned/embeddings/05-2d-embedding-map.md
+++ b/docs/features/planned/embeddings/05-2d-embedding-map.md
@@ -1,34 +1,42 @@
 # 05 - 2D Embedding Map (Frontend)
 
-*Status: **Planned***
+*Status: **In Progress (Scaffolded on March 28, 2026)***
 
 *Part of [Embedding Applications - Frontend Implementation Index](README.md).*
 
 ## Goal
 
-Provide a visual cluster map of the entire photo collection or a specific folder, based on UMAP dimensionality reduction of image embeddings.
+Provide a visual cluster map of the entire photo collection or a specific folder, based on dimensionality reduction (UMAP/t-SNE) of image embeddings.
+
+## Current Implementation Phase
+
+A minimal scaffold now exists so backend integration can proceed incrementally:
+
+1. **View routing is available** in `src/AppContent.tsx` via the `embeddings` app view.
+2. **Component placeholder exists** at `src/components/Embeddings/EmbeddingMap.tsx`.
+3. **State contract is established** for `loading`, `error`, `empty`, and `points` rendering.
 
 ## UI Integration Points
 
-1. **New View Mode (`src/AppContent.tsx`)**
-   - Add `EMBEDDING_MAP` to the view routing.
-   - Accessible via a button in the breadcrumbs or sidebar.
+1. **App View (`src/AppContent.tsx`)**
+   - `embeddings` route is selectable from sidebar view navigation.
+   - Current implementation renders the placeholder `EmbeddingMap` component.
 
-2. **WebGL Renderer (`src/components/EmbeddingMap/EmbeddingMap.tsx`)**
-   - Render images as points in 2D space.
-   - Points are colored by folder, score, or rating.
-   - Interactive zoom/pan.
+2. **Map Renderer (`src/components/Embeddings/EmbeddingMap.tsx`)**
+   - Props contract includes projected point coordinates (`x`, `y`) and image identity (`id`).
+   - Current rendering is intentionally non-WebGL and placeholder-only.
 
 3. **Point Interaction**
-   - **Lasso/Box Selection**: Select multiple images for batch tagging.
-   - **Thumbnail Preview**: High-speed thumbnail popups on hover.
+   - Single-point callback contract is present (`onSelectPoint`) to open/navigate images.
+   - Future lasso/box selection and hover previews remain planned.
 
-## IPC / Data Flow
+## IPC / Data Flow (Planned)
 
-- **Fetch Coordinates**: `window.electron.getEmbeddingCoordinates({ folderId, method: 'UMAP' })`.
-- **Response**: `typed array` or `JSON` containing `id, x, y, color`.
+- **Fetch Coordinates**: extend bridge/electron API with an embeddings projection endpoint.
+- **Expected Response**: list/typed payload with `id, x, y` and optional display metadata.
 
 ## Design Considerations
 
-- **Scale**: The map should handle 50,000+ images using instanced rendering in WebGL.
-- **Clustering**: Visually distinct clusters often represent "bursts" or "locations" automatically.
+- **Scale target**: 50k+ points, requiring batched rendering (WebGL/canvas).
+- **Progressive loading**: support folder-scope loading first, then full library.
+- **State resiliency**: keep loading/error/empty states stable during backend rollout.

--- a/docs/features/planned/embeddings/06-smart-stack-representative.md
+++ b/docs/features/planned/embeddings/06-smart-stack-representative.md
@@ -1,28 +1,42 @@
 # 06 - Smart Stack Representative (Frontend)
 
-*Status: **Planned***
+*Status: **In Progress (Preference + request threading scaffolded on March 28, 2026)***
 
 *Part of [Embedding Applications - Frontend Implementation Index](README.md).*
 
 ## Goal
 
-Allow users to configure whether stack covers display the highest-scoring image or the most "representative" image (the one closest to the stack's embedding centroid).
+Allow users to configure whether stack covers display the highest-scoring image or a future "representative" image (e.g., nearest stack centroid).
+
+## Current Implementation Phase
+
+The UI + request threading scaffolding is in place:
+
+1. **Settings UI component**: `src/components/Settings/SelectionSettings.tsx`.
+2. **Persisted config key**: `selection.smartCoverEnabled` (saved via existing config bridge).
+3. **Stack request threading**:
+   - `smartCover` is now included in stack query options.
+   - rebuild calls now pass context `{ smartCover }` through bridge/preload/main/server layers.
+
+> Note: Stack representative selection logic is still backend-driven and not yet implemented in SQL/embedding logic.
 
 ## UI Integration Points
 
-1. **Settings View (`src/components/Settings/SelectionSettings.tsx`)**
-   - Add a toggle: **"Use Smart Stack Covers (Centroid)"**.
-   - This setting dictates which `image_id` the backend returns as the `cover_id` for stacks.
+1. **Settings Modal Integration**
+   - `SettingsModal.tsx` now renders `SelectionSettings` and updates selection preferences.
 
-2. **Stack Rendering**
-   - Display a "Target" icon badge on stack covers when chosen via centroid logic.
-   - This provides transparency to the user why a lower-scoring image might be the cover.
+2. **Stack Rendering Behavior (Current)**
+   - Existing visual stack rendering remains unchanged.
+   - Smart Cover currently affects request context only.
 
 ## IPC / Configuration Flow
 
-- **Setting**: Update `clustering.smart_cover_enabled` in `config.json`.
-- **Effect**: Next time stacks are queried or rebuilt, the backend uses embedding proximity to choose the cover.
+- **Setting key**: `selection.smartCoverEnabled` in saved app config.
+- **Runtime behavior**: value is loaded into `AppContent` and passed into stack fetch/rebuild calls.
+- **Future backend effect**: stack cover selection should switch to representative image when enabled.
 
-## Design Considerations
+## Next Steps
 
-- **Hybrid Mode**: Optionally allow a "Best of Both" where it chooses the highest-scoring image within the 10% closest to the centroid.
+1. Implement backend representative-image selection strategy.
+2. Surface representative-selection indicators on stack cards.
+3. Add test coverage verifying request context propagation and config persistence.

--- a/docs/features/planned/embeddings/TODO.md
+++ b/docs/features/planned/embeddings/TODO.md
@@ -1,33 +1,33 @@
 # Embedding Features TODO List
 
-This document tracks the remaining work for the embedding-based features in the Electron Gallery.
+This document tracks remaining work for embedding-related features in the Electron Gallery.
 
-> **Source of truth & update order:** Embeddings feature-detail mirror (owner: feature maintainers). Update only after `TODO.md` and `docs/planning/01-roadmap-todo.md`; use `docs/integration/TODO.md` to confirm backend milestone status before changing Gradio/API states.
-
-## 🟢 Implemented
-- [x] **Diversity-Aware Selection**: Settings and MMR logic integrated.
-- [x] **Near-Duplicate Detection**: Duplicate finder view and IPC bridge.
-- [x] **"More Like This" Search**: Similarity search drawer and context menu.
+## ✅ Implemented
+- [x] Diversity-Aware Selection: settings + MMR logic integrated.
+- [x] Near-Duplicate Detection: duplicate finder view + bridge.
+- [x] "More Like This": similarity drawer + backend query path.
 
 ## 🟡 In Progress
-- [ ] **Gradio Integration**: Enhance IPC/WebSocket bridge for real-time AI updates (job progress subscription still pending).
+- [ ] Gradio/Backend integration hardening (job streaming and richer status wiring still pending).
+- [ ] Feature 5 (2D Embedding Map): scaffolded UI route and placeholder component; backend projection + renderer still pending.
+- [ ] Feature 6 (Smart Stack Representative): toggle + persistence + request threading scaffolded; backend representative selection still pending.
 
-## 🔴 Planned (Missing)
+## 🔴 Planned
 ### Feature 3: Tag Propagation
-- [ ] Implement `propagateTags` service call (dry-run/apply).
-- [ ] Add "AI Suggestions" section to `ImageViewer.tsx` metadata sidebar.
-- [ ] Add "Accept/Reject" interaction logic.
+- [ ] Wire full `propagateTags` dry-run/apply UX.
+- [ ] Add AI suggestion acceptance/rejection workflow in image details UI.
 
 ### Feature 4: Outlier Detection
-- [ ] Add "Show Outliers" toggle to `FilterPanel.tsx`.
-- [ ] Implement visual badge/highlight for outliers in `GalleryGrid.tsx`.
-- [ ] Connect to backend outlier detection endpoint.
+- [ ] Add outlier controls to filtering UI.
+- [ ] Add outlier highlighting/badging in grid.
+- [ ] Add endpoint integration and result state handling.
 
-### Feature 5: 2D Embedding Map
-- [ ] Create `EmbeddingMap.tsx` component.
-- [ ] Implement WebGL-based visualization of 1280-d feature vectors projected to 2D.
-- [ ] Add navigation to map view in `AppContent.tsx`.
+### Feature 5: 2D Embedding Map (remaining)
+- [ ] Add embeddings projection endpoint to bridge/backend.
+- [ ] Replace placeholder with performant canvas/WebGL renderer.
+- [ ] Add map interactions (pan/zoom/hover/lasso).
 
-### Feature 6: Smart Stack Representative
-- [ ] Add "Smart Cover" toggle to `SelectionSettings.tsx`.
-- [ ] Implement cover selection logic based on stack centroid in IPC/Backend.
+### Feature 6: Smart Stack Representative (remaining)
+- [ ] Implement backend representative-image selection (embedding centroid or hybrid).
+- [ ] Expose representative metadata to frontend stack cards.
+- [ ] Add UI marker/badge explaining representative-selected covers.

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -390,6 +390,7 @@ export interface ImageQueryOptions {
     keyword?: string;
     sortBy?: string;
     order?: 'ASC' | 'DESC';
+    smartCover?: boolean;
 }
 
 export async function getImages(options: ImageQueryOptions = {}): Promise<unknown[]> {
@@ -1008,8 +1009,10 @@ export async function ensureStackCacheTable(): Promise<void> {
 let rebuildPromise: Promise<number> | null = null;
 let pendingRebuild: boolean = false;
 
-export async function rebuildStackCache(): Promise<number> {
+export async function rebuildStackCache(context: { smartCover?: boolean } = {}): Promise<number> {
     // If a rebuild is already in progress, queue another one to run when it finishes
+    console.log(`[DB] rebuildStackCache requested (smartCover=${context.smartCover === true})`);
+
     if (rebuildPromise) {
         console.log('[DB] Stack cache rebuild already in progress, queuing another request...');
         pendingRebuild = true;

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1007,15 +1007,14 @@ export async function ensureStackCacheTable(): Promise<void> {
 }
 
 let rebuildPromise: Promise<number> | null = null;
-let pendingRebuild: boolean = false;
+/** Merged context for a follow-up rebuild when callers arrive while `rebuildPromise` is active. */
+let pendingAfterCurrent: { smartCover?: boolean } | null = null;
 
 export async function rebuildStackCache(context: { smartCover?: boolean } = {}): Promise<number> {
-    // If a rebuild is already in progress, queue another one to run when it finishes
-    console.log(`[DB] rebuildStackCache requested (smartCover=${context.smartCover === true})`);
-
+    // If a rebuild is already in progress, queue one follow-up and merge caller context (last wins per key).
     if (rebuildPromise) {
         console.log('[DB] Stack cache rebuild already in progress, queuing another request...');
-        pendingRebuild = true;
+        pendingAfterCurrent = { ...(pendingAfterCurrent ?? {}), ...context };
         return rebuildPromise;
     }
 
@@ -1071,12 +1070,12 @@ export async function rebuildStackCache(context: { smartCover?: boolean } = {}):
             });
         } finally {
             rebuildPromise = null;
-            if (pendingRebuild) {
-                pendingRebuild = false;
+            const nextContext = pendingAfterCurrent;
+            pendingAfterCurrent = null;
+            if (nextContext !== null) {
                 console.log('[DB] Running queued stack cache rebuild...');
-                // intentionally do not await here so we don't block the previous caller
-                // but we start the next cycle
-                rebuildStackCache().catch(console.error);
+                // Do not await — start the next cycle without blocking the previous caller.
+                rebuildStackCache(nextContext).catch(console.error);
             }
         }
     };
@@ -1087,6 +1086,7 @@ export async function rebuildStackCache(context: { smartCover?: boolean } = {}):
 
 export async function getStacks(options: StackQueryOptions = {}): Promise<unknown[]> {
     const { limit = 50, offset = 0, folderId, folderIds, minRating, colorLabel, keyword, sortBy = 'score_general', order = 'DESC' } = options;
+    // `options.smartCover` is forwarded from the UI for future representative/cover selection; not used in SQL yet.
 
     await ensureStackCacheTable();
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -624,8 +624,8 @@ async function startFullApplication(): Promise<void> {
         return await db.getStackCount(options);
     }));
 
-    ipcMain.handle('db:rebuild-stack-cache', wrapIpcHandler(async () => {
-        const count = await db.rebuildStackCache();
+    ipcMain.handle('db:rebuild-stack-cache', wrapIpcHandler(async (_, context) => {
+        const count = await db.rebuildStackCache(context ?? {});
         return { success: true, count };
     }));
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -96,8 +96,8 @@ contextBridge.exposeInMainWorld('electron', {
         const response = await ipcRenderer.invoke('db:get-stack-count', options);
         return unwrapEnvelope<number>(response);
     },
-    rebuildStackCache: async () => {
-        const response = await ipcRenderer.invoke('db:rebuild-stack-cache');
+    rebuildStackCache: async (context?: { smartCover?: boolean }) => {
+        const response = await ipcRenderer.invoke('db:rebuild-stack-cache', context ?? {});
         return unwrapEnvelope<{ success: boolean; count: number }>(response);
     },
     log: async (level: string, message: string, data?: unknown) => {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -13,6 +13,7 @@ export interface ImageQueryOptions {
     keyword?: string;
     sortBy?: string;
     order?: 'ASC' | 'DESC';
+    smartCover?: boolean;
 }
 
 export interface ImageRow {

--- a/server/index.ts
+++ b/server/index.ts
@@ -169,9 +169,9 @@ async function startServer() {
     }));
 
     // DB: rebuild stack cache
-    router.post('/db/rebuild-stack-cache', wrap(async (_req, res) => {
+    router.post('/db/rebuild-stack-cache', wrap(async (req, res) => {
         try {
-            const count = await db.rebuildStackCache();
+            const count = await db.rebuildStackCache((req.body ?? {}) as { smartCover?: boolean });
             ok(res, { success: true, count });
         } catch (e) { fail(res, e); }
     }));

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { MainLayout } from './components/Layout/MainLayout';
 import { useImages, useKeywords, useStacks } from './hooks/useDatabase';
 import { useFolders } from './hooks/useFolders';
@@ -16,6 +16,7 @@ import { RunsPage } from './components/Runs/RunsPage';
 import { ImportModal } from './components/Import/ImportModal';
 import { Loader2, ChevronRight } from 'lucide-react';
 import { useState } from 'react';
+import { bridge } from './bridge';
 import { useElectronListeners } from './hooks/useElectronListeners';
 import { useGalleryNavigation } from './hooks/useGalleryNavigation';
 import { useStacksMode } from './hooks/useStacksMode';
@@ -23,6 +24,7 @@ import { useImageOpener } from './hooks/useImageOpener';
 import { useGalleryWebSocket } from './hooks/useGalleryWebSocket';
 import breadcrumbStyles from './styles/breadcrumbs.module.css';
 import toggleStyles from './styles/toggle.module.css';
+import { EmbeddingMap, type ProjectedEmbeddingPoint } from './components/Embeddings/EmbeddingMap';
 
 interface AppContentProps {
   isConnected: boolean;
@@ -30,6 +32,34 @@ interface AppContentProps {
 
 function AppContent({ isConnected }: AppContentProps) {
   const [filters, setFilters] = useState<FilterState>({ minRating: 0, sortBy: 'score_general', order: 'DESC' });
+  const [smartCoverEnabled, setSmartCoverEnabled] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadConfig = async () => {
+      try {
+        const config = await bridge.getConfig();
+        if (!mounted) return;
+        setSmartCoverEnabled(Boolean(config.selection?.smartCoverEnabled));
+      } catch (err) {
+        console.error('Failed to load selection config', err);
+      }
+    };
+
+    void loadConfig();
+
+    const handleConfigUpdated = (evt: Event) => {
+      const next = (evt as CustomEvent<{ selection?: { smartCoverEnabled?: boolean } }>).detail;
+      setSmartCoverEnabled(Boolean(next?.selection?.smartCoverEnabled));
+    };
+
+    window.addEventListener('config-updated', handleConfigUpdated as EventListener);
+    return () => {
+      mounted = false;
+      window.removeEventListener('config-updated', handleConfigUpdated as EventListener);
+    };
+  }, []);
 
   const { folders, loading: foldersLoading, refresh: refreshFolders } = useFolders();
   const { keywords, loading: keywordsLoading, fetch: fetchKeywords } = useKeywords();
@@ -60,13 +90,18 @@ function AppContent({ isConnected }: AppContentProps) {
     [filters, subfolderIds],
   );
 
+  const stackFilters = useMemo(
+    () => ({ ...imageFilters, smartCover: smartCoverEnabled }),
+    [imageFilters, smartCoverEnabled],
+  );
+
   const {
     images, loading: imagesLoading, loadMore, totalCount, removeImage, refresh: refreshImages,
   } = useImages(50, selectedFolderId, imageFilters);
 
   const {
     stacks, loading: stacksLoading, loadMore: loadMoreStacks, totalCount: stacksTotalCount, refresh: refreshStacks,
-  } = useStacks(50, selectedFolderId, imageFilters);
+  } = useStacks(50, selectedFolderId, stackFilters);
 
   const {
     stacksMode, enableStacksMode,
@@ -78,7 +113,7 @@ function AppContent({ isConnected }: AppContentProps) {
     clearStack,
     handleSelectStack: handleSelectStackBase,
     handleImageDeleteFromStack,
-  } = useStacksMode(selectedFolderId, filters, refreshStacks);
+  } = useStacksMode(selectedFolderId, filters, refreshStacks, smartCoverEnabled);
 
   // Keep refs up to date for WebSocket callbacks
   stacksModeRef.current = stacksMode;
@@ -154,12 +189,14 @@ function AppContent({ isConnected }: AppContentProps) {
     ? (stacksLoading && stacks.length === 0)
     : (activeStackId ? stackImagesLoading : (imagesLoading && images.length === 0));
 
-  const headerTitle = activeStackId
-    ? `Stack #${activeStackId}`
-    : (currentFolder ? (currentFolder.title || 'Folder') : 'Image Gallery');
+  const headerTitle = currentView === 'embeddings'
+    ? 'Embeddings Map'
+    : activeStackId
+      ? `Stack #${activeStackId}`
+      : (currentFolder ? (currentFolder.title || 'Folder') : 'Image Gallery');
 
   const breadcrumbsNode = useMemo(() => {
-    if (currentView === 'duplicates') return null;
+    if (currentView === 'duplicates' || currentView === 'embeddings') return null;
 
     type BreadcrumbPart = { label: string; onClick: () => void; isActive: boolean };
     const parts: BreadcrumbPart[] = [];
@@ -236,6 +273,32 @@ function AppContent({ isConnected }: AppContentProps) {
         }
         sidebar={
           <div style={{ padding: 10, display: 'flex', flexDirection: 'column', height: '100%' }}>
+            <div style={{ marginBottom: 12, display: 'grid', gap: 6 }}>
+              {([
+                { key: 'gallery', label: 'Gallery' },
+                { key: 'runs', label: 'Runs' },
+                { key: 'duplicates', label: 'Duplicates' },
+                { key: 'embeddings', label: 'Embeddings' },
+              ] as const).map((view) => (
+                <button
+                  key={view.key}
+                  onClick={() => setCurrentView(view.key)}
+                  style={{
+                    width: '100%',
+                    padding: '8px 10px',
+                    backgroundColor: currentView === view.key ? '#4caf50' : '#2d2d2d',
+                    color: '#fff',
+                    border: '1px solid #4a4a4a',
+                    borderRadius: 4,
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontWeight: currentView === view.key ? 'bold' : 500,
+                  }}
+                >
+                  {view.label}
+                </button>
+              ))}
+            </div>
 
             {currentView === 'duplicates' && (
               <div style={{ marginBottom: 15 }}>
@@ -365,6 +428,15 @@ function AppContent({ isConnected }: AppContentProps) {
               />
             ) : currentView === 'duplicates' ? (
               <DuplicateFinder currentFolder={currentFolder} />
+            ) : currentView === 'embeddings' ? (
+              <EmbeddingMap
+                points={[]}
+                isLoading={false}
+                error={null}
+                onSelectPoint={(point: ProjectedEmbeddingPoint) => {
+                  void openImageById(point.id);
+                }}
+              />
             ) : (
               <>
                 {isInitialGridLoading && (

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -112,7 +112,7 @@ function createHttpBridge(): Window['electron'] {
 
         getStackCount: (options?) => get('/db/stack-count', options as Record<string, unknown> | undefined),
 
-        rebuildStackCache: () => post('/db/rebuild-stack-cache'),
+        rebuildStackCache: (context) => post('/db/rebuild-stack-cache', context ?? {}),
 
         log: (level, message, data?) => {
             const args = data !== undefined ? [message, data] : [message];

--- a/src/components/Embeddings/EmbeddingMap.tsx
+++ b/src/components/Embeddings/EmbeddingMap.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+export interface ProjectedEmbeddingPoint {
+  id: number;
+  x: number;
+  y: number;
+  fileName?: string;
+  thumbnailPath?: string;
+  color?: string;
+  stackId?: number | null;
+}
+
+interface EmbeddingMapProps {
+  points: ProjectedEmbeddingPoint[];
+  isLoading?: boolean;
+  error?: string | null;
+  onRetry?: () => void;
+  onSelectPoint?: (point: ProjectedEmbeddingPoint) => void;
+}
+
+/**
+ * Placeholder scaffold for the future 2D embeddings map.
+ *
+ * This component intentionally focuses on basic state handling and a
+ * stable props contract so backend integration can be added incrementally.
+ */
+export const EmbeddingMap: React.FC<EmbeddingMapProps> = ({
+  points,
+  isLoading = false,
+  error = null,
+  onRetry,
+  onSelectPoint,
+}) => {
+  if (isLoading) {
+    return (
+      <div style={{ padding: 24, color: '#aaa' }}>
+        Loading embedding map projection…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ padding: 24 }}>
+        <div style={{ color: '#ff6b6b', marginBottom: 12 }}>Failed to load embedding map: {error}</div>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            style={{
+              padding: '8px 14px',
+              borderRadius: 6,
+              border: '1px solid #555',
+              background: '#2d2d2d',
+              color: '#e5e5e5',
+              cursor: 'pointer',
+            }}
+          >
+            Retry
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  if (!points.length) {
+    return (
+      <div style={{ padding: 24, color: '#aaa' }}>
+        No projected points available yet. Run embedding + projection jobs to populate this view.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 20, height: '100%', overflow: 'auto' }}>
+      <div style={{ marginBottom: 10, color: '#aaa' }}>
+        Embedding map placeholder ({points.length} points)
+      </div>
+      <div
+        style={{
+          border: '1px dashed #555',
+          borderRadius: 8,
+          minHeight: 320,
+          padding: 16,
+          background: '#1c1c1c',
+        }}
+      >
+        <div style={{ marginBottom: 12, color: '#888', fontSize: '0.9em' }}>
+          Rendering scaffold only. WebGL/canvas plotting will be added in a follow-up.
+        </div>
+        <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 8 }}>
+          {points.slice(0, 50).map((point) => (
+            <li key={point.id}>
+              <button
+                onClick={() => onSelectPoint?.(point)}
+                style={{
+                  width: '100%',
+                  textAlign: 'left',
+                  border: '1px solid #3a3a3a',
+                  background: '#252526',
+                  color: '#ddd',
+                  borderRadius: 6,
+                  padding: '8px 10px',
+                  cursor: onSelectPoint ? 'pointer' : 'default',
+                }}
+              >
+                #{point.id} · ({point.x.toFixed(3)}, {point.y.toFixed(3)}){point.fileName ? ` · ${point.fileName}` : ''}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Settings/SelectionSettings.tsx
+++ b/src/components/Settings/SelectionSettings.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface SelectionSettingsProps {
+  smartCoverEnabled: boolean;
+  onSmartCoverChange: (enabled: boolean) => void;
+}
+
+export const SelectionSettings: React.FC<SelectionSettingsProps> = ({
+  smartCoverEnabled,
+  onSmartCoverChange,
+}) => {
+  return (
+    <section>
+      <h3 style={{ margin: '0 0 8px', fontSize: '1em', color: '#e0e0e0' }}>Selection</h3>
+      <div style={{ fontSize: '0.85em', color: '#999', marginBottom: 12 }}>
+        Tune stack cover selection behavior.
+      </div>
+
+      <label
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '10px 12px',
+          border: '1px solid #3e3e3e',
+          borderRadius: 6,
+          background: '#2a2a2a',
+          gap: 16,
+        }}
+      >
+        <div>
+          <div style={{ fontWeight: 600, color: '#ddd' }}>Smart Cover</div>
+          <div style={{ fontSize: '0.85em', color: '#9a9a9a' }}>
+            Prefer representative stack covers when available.
+          </div>
+        </div>
+        <input
+          type="checkbox"
+          checked={smartCoverEnabled}
+          onChange={(e) => onSmartCoverChange(e.target.checked)}
+          aria-label="Enable Smart Cover"
+        />
+      </label>
+    </section>
+  );
+};

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { bridge } from '../../bridge';
+import { SelectionSettings } from './SelectionSettings';
 
 interface AppConfig {
+    selection?: {
+        smartCoverEnabled?: boolean;
+        [key: string]: unknown;
+    };
     [key: string]: unknown;
 }
 
@@ -88,10 +93,25 @@ export const SettingsModal: React.FC<Props> = ({ isOpen, onClose }) => {
                         <div style={{ color: '#aaa', textAlign: 'center', padding: '20px' }}>Loading settings...</div>
                     ) : error ? (
                         <div style={{ color: '#ff6b6b', padding: '12px', background: 'rgba(255,107,107,0.1)', borderRadius: 4, border: '1px solid rgba(255,107,107,0.3)' }}>{error}</div>
+                    ) : config ? (
+                        <SelectionSettings
+                            smartCoverEnabled={Boolean(config.selection?.smartCoverEnabled)}
+                            onSmartCoverChange={(enabled) => {
+                                setConfig((prev) => {
+                                    if (!prev) return prev;
+                                    return {
+                                        ...prev,
+                                        selection: {
+                                            ...(prev.selection ?? {}),
+                                            smartCoverEnabled: enabled,
+                                        },
+                                    };
+                                });
+                            }}
+                        />
                     ) : (
                         <div style={{ color: '#aaa', textAlign: 'center', padding: '40px 20px' }}>
                             <div style={{ fontSize: '1.2em', marginBottom: '10px' }}>No configurable preferences.</div>
-                            <div style={{ fontSize: '0.9em' }}>General settings are currently managed automatically.</div>
                         </div>
                     )}
                 </div>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -23,6 +23,7 @@ interface ImageQueryOptions {
     keyword?: string;
     sortBy?: string;
     order?: 'ASC' | 'DESC';
+    smartCover?: boolean;
 }
 
 interface ImageRow {
@@ -199,7 +200,7 @@ declare global {
             getStacks: (options?: ImageQueryOptions) => Promise<ImageRow[]>;
             getImagesByStack: (stackId: number | null, options?: ImageQueryOptions) => Promise<ImageRow[]>;
             getStackCount: (options?: ImageQueryOptions) => Promise<number>;
-            rebuildStackCache: () => Promise<{ success: boolean; count: number }>;
+            rebuildStackCache: (context?: { smartCover?: boolean }) => Promise<{ success: boolean; count: number }>;
             log: (level: string, message: string, data?: unknown) => Promise<boolean>;
             extractNefPreview: (filePath: string) => Promise<{
                 success: boolean;

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -13,6 +13,7 @@ interface ImageQueryOptions {
     keyword?: string;
     sortBy?: string;
     order?: 'ASC' | 'DESC';
+    smartCover?: boolean;
 }
 
 interface ImageRow {

--- a/src/hooks/useElectronListeners.ts
+++ b/src/hooks/useElectronListeners.ts
@@ -14,7 +14,7 @@ export function useElectronListeners() {
   const [isDiagnosticsOpen, setIsDiagnosticsOpen] = useState(false);
   const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [importFolderPath, setImportFolderPath] = useState('');
-  const [currentView, setCurrentView] = useState<'gallery' | 'duplicates' | 'runs'>('gallery');
+  const [currentView, setCurrentView] = useState<'gallery' | 'duplicates' | 'runs' | 'embeddings'>('gallery');
 
   useEffect(() => {
     const cleanupSettings = bridge.onOpenSettings(() => {

--- a/src/hooks/useStacksMode.ts
+++ b/src/hooks/useStacksMode.ts
@@ -55,6 +55,8 @@ export function useStacksMode(
   const loadStackImagesRef = useRef(loadStackImages);
   loadStackImagesRef.current = loadStackImages;
 
+  const prevSmartCoverRef = useRef(smartCoverEnabled);
+
   // Reload stack images when activeStackId or filters change
   useEffect(() => {
     if (activeStackId !== null) {
@@ -74,6 +76,18 @@ export function useStacksMode(
       });
     }
   }, [stacksMode, cacheBuilt, refreshStacks, smartCoverEnabled]);
+
+  // After cache exists, changing Smart Cover should rebuild so rep rows stay consistent when backend honors the flag.
+  useEffect(() => {
+    const prev = prevSmartCoverRef.current;
+    prevSmartCoverRef.current = smartCoverEnabled;
+    if (!stacksMode || !cacheBuilt || prev === smartCoverEnabled) return;
+    bridge.rebuildStackCache({ smartCover: smartCoverEnabled }).then(() => {
+      refreshStacks();
+    }).catch((err) => {
+      console.error('[App] Failed to rebuild stack cache after Smart Cover change:', err);
+    });
+  }, [smartCoverEnabled, stacksMode, cacheBuilt, refreshStacks]);
 
   const clearStack = () => {
     setActiveStackId(null);

--- a/src/hooks/useStacksMode.ts
+++ b/src/hooks/useStacksMode.ts
@@ -30,6 +30,7 @@ export function useStacksMode(
   selectedFolderId: number | undefined,
   filters: FilterState,
   refreshStacks: (opts?: { preserveItems?: boolean }) => void,
+  smartCoverEnabled: boolean,
 ) {
   const [stacksMode, setStacksMode] = useState(false);
   const [activeStackId, setActiveStackId] = useState<number | null>(null);
@@ -64,7 +65,7 @@ export function useStacksMode(
   // Rebuild stack cache when stacks mode is first enabled
   useEffect(() => {
     if (stacksMode && !cacheBuilt) {
-      bridge.rebuildStackCache().then((result) => {
+      bridge.rebuildStackCache({ smartCover: smartCoverEnabled }).then((result) => {
         console.log('[App] Stack cache rebuild result:', result);
         setCacheBuilt(true);
         refreshStacks();
@@ -72,7 +73,7 @@ export function useStacksMode(
         console.error('[App] Failed to rebuild stack cache:', err);
       });
     }
-  }, [stacksMode, cacheBuilt, refreshStacks]);
+  }, [stacksMode, cacheBuilt, refreshStacks, smartCoverEnabled]);
 
   const clearStack = () => {
     setActiveStackId(null);


### PR DESCRIPTION
### Motivation
- Provide minimal frontend scaffold for a 2D embeddings map so backend projection work can be integrated incrementally.
- Add a user-configurable preference for choosing smart/representative stack covers and thread that preference into stack queries and rebuilds so backend logic can use it later.
- Establish a stable props/IPC contract for future embedding and representative-selection work without changing runtime behavior yet.

### Description
- Added a placeholder embeddings component `src/components/Embeddings/EmbeddingMap.tsx` with a typed `ProjectedEmbeddingPoint` contract and explicit `loading`, `error`, `empty` and `onSelectPoint` behaviors.
- Introduced an `embeddings` app view and sidebar navigation entry by updating `src/hooks/useElectronListeners.ts` and routing the view from `src/AppContent.tsx` to render the new `EmbeddingMap` scaffold.
- Added `SelectionSettings` at `src/components/Settings/SelectionSettings.tsx` and integrated it into `SettingsModal.tsx`, persisting the preference under the config key `selection.smartCoverEnabled` and dispatching a `config-updated` event on save.
- Threaded the Smart Cover preference through the data/request path by adding `smartCover?: boolean` to `ImageQueryOptions`, passing `smartCover` in stack list filters, passing rebuild context to `rebuildStackCache`, and updating `src/bridge.ts`, `electron/preload.ts`, `electron/main.ts`, `server/index.ts`, and `electron/db.ts` to accept and forward an optional `{ smartCover?: boolean }` context.
- Updated planning docs under `docs/features/planned/embeddings/` to reflect the new component paths and current scaffold/config-threading status.

### Testing
- Ran unit tests with `npm run -s test:run`, all tests passed (`13 files, 94 tests`).
- Ran type-check with `npx tsc --noEmit`, which completed successfully (non-fatal npm env warning only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74c3225188323b12cbb89c1a3e314)