### PR TITLE
Update gallery MCP tooling and sync unfinished TODO tracking

### DIFF
--- a/.agent/skills/image-scoring-mcp/SKILL.md
+++ b/.agent/skills/image-scoring-mcp/SKILL.md
@@ -1,90 +1,120 @@
 ---
 name: image-scoring-mcp
-description: How to use the image-scoring MCP server for database diagnostics, querying images, and checking system health.
+description: How to use the gallery MCP server plus the optional backend DB MCP for diagnostics, API probing, and renderer inspection.
 ---
 
 # Image Scoring MCP Server
 
-In this **Electron** workspace, the stdio MCP entry is **`imgscore-el-stdio`** (`cwd` / `PYTHONPATH` → sibling **image-scoring**). The **Python** repo uses **`imgscore-py-stdio`** when that workspace is open. For WebUI / **`execute_code`**, add **`imgscore-el-sse`**. **`imgscore-el-stdio` may be disabled by default** — enable when you need DB debugging beyond the Electron app.
+The gallery workspace now has two distinct MCP paths:
 
-## MCP Config
+- **Primary gallery MCP:** **`imgscore-el-gallery`** (Node stdio, `mcp-server/dist/index.js`)
+- **Optional full DB MCP:** **`imgscore-el-stdio`** (Python `modules.mcp_server`, disabled by default in the gallery repo)
 
-In `mcp_config.json`, the server is configured as:
+Use the gallery MCP first. Only switch to the Python DB MCP when you need direct database diagnostics such as `query_images` or `execute_sql`.
+
+## Start Here
+
+1. Run **`gallery_status`**.
+   - This tells you whether **`python_api`** is reachable for **`api_*`** tools.
+   - This tells you whether **`electron_cdp`** is reachable for **`cdp_*`** tools.
+2. Use the always-available local gallery tools for config/log/system inspection.
+3. Use **`api_*`** only when `gallery_status.python_api.reachable` is true.
+4. Use **`cdp_*`** only when `gallery_status.electron_cdp.reachable` is true.
+5. If you need SQL/image DB diagnostics, enable **`imgscore-el-stdio`** or open the backend workspace.
+
+## Gallery MCP Tools (`imgscore-el-gallery`)
+
+### Local Diagnostics
+
+| Tool | Purpose |
+|------|---------|
+| `gallery_status` | Probe FastAPI + Electron CDP reachability before choosing `api_*` or `cdp_*` |
+| `get_electron_logs` | Read the latest Electron session log |
+| `get_electron_config` | Read the gallery `config.json` |
+| `get_system_stats` | Inspect local machine CPU/memory/uptime |
+
+### FastAPI Probes
+
+Use these only when `gallery_status.python_api.reachable` is true.
+
+| Tool | Purpose |
+|------|---------|
+| `api_health` | Combined `/api/health` + `/api/status` snapshot |
+| `api_job_status` | Recent jobs or a specific job/run |
+| `api_run_stages` | Stage breakdown for a run/job id |
+| `api_probe` | Timed GET against an arbitrary backend-relative path |
+| `api_runner_status` | Scoring/tagging/clustering runner state |
+
+### Electron CDP Tools
+
+Use these only when `gallery_status.electron_cdp.reachable` is true.
+
+| Tool | Purpose |
+|------|---------|
+| `cdp_screenshot` | Capture the Electron renderer as a PNG |
+| `cdp_evaluate` | Run JS in the renderer page context |
+| `cdp_console_logs` | Collect renderer console output for a short window |
+
+## Optional Full DB MCP (`imgscore-el-stdio`)
+
+This server points at sibling **`image-scoring-backend`** and is disabled by default in `.cursor/mcp.json`.
 
 ```json
 "imgscore-el-stdio": {
     "command": "python",
     "args": ["-m", "modules.mcp_server"],
-    "cwd": "d:\\Projects\\image-scoring",
-    "env": { "PYTHONPATH": "d:\\Projects\\image-scoring" },
+    "cwd": "d:\\Projects\\image-scoring-backend",
+    "env": { "PYTHONPATH": "d:\\Projects\\image-scoring-backend" },
     "disabled": true
 }
 ```
 
-> [!NOTE]
-> When this server is disabled, its tools are unavailable. Ask the user to enable it before attempting to use these tools.
+When disabled, its tools are unavailable unless the user enables the server or uses the backend workspace (`imgscore-py-stdio`).
 
-Add **`imgscore-el-sse`** with `"url": "http://127.0.0.1:7860/mcp/sse"` when the Python WebUI is running and you need **`execute_code`** (`ENABLE_MCP_EXECUTE_CODE=1` on the WebUI).
+Use it for:
 
-## Available Tools
-
-### Diagnostic Tools
-
-| Tool | Purpose | When to Use |
-|------|---------|-------------|
-| `get_error_summary` | Overview of job failures and missing scores | Investigating why images have no scores |
-| `check_database_health` | Integrity check for database records | Verifying DB consistency after bulk operations |
-| `get_model_status` | GPU and model status | Understanding why scoring may be slow or failing |
-
-### Data Query Tools
-
-| Tool | Purpose | When to Use |
-|------|---------|-------------|
-| `query_images` | Advanced filtering by scores, ratings, labels | Debugging filter issues in the gallery |
-| `get_image_details` | Full record for a specific file path | Verifying a specific image's data |
-| `execute_sql` | Direct SELECT queries | Complex analysis not covered by other tools |
+- `query_images`
+- `get_image_details`
+- `execute_sql`
+- `check_database_health`
+- `get_model_status`
 
 ## Common Workflows
 
-### 1. Investigate Missing Scores
-```
-1. get_error_summary          → See which models failed
-2. get_model_status           → Check if GPU/models are available
-3. query_images (with filters) → Verify which images are affected
+### 1. Decide which MCP path to use
+
+```text
+1. gallery_status
+2. If python_api.reachable -> use api_*
+3. If electron_cdp.reachable -> use cdp_*
+4. If you need SQL/image DB internals -> enable imgscore-el-stdio
 ```
 
-### 2. Verify Score Values
-```
-1. get_image_details (by path) → See raw model output values
-2. execute_sql                  → Compare against expected normalization
+### 2. Inspect backend job state from the gallery workspace
+
+```text
+1. gallery_status
+2. api_health
+3. api_job_status or api_run_stages
+4. api_runner_status
 ```
 
-### 3. Database Health Check
-```
-1. check_database_health       → Look for orphaned records, NULL scores
-2. execute_sql                  → Run targeted queries if issues found
-```
+### 3. Inspect live renderer/UI state
 
-### 4. Debug Gallery Filtering
-When the gallery shows unexpected results:
-```
-1. query_images (same filters as gallery) → Compare DB results with UI
-2. get_image_details (specific image)     → Verify individual record values
-3. execute_sql (raw query)                → Check the exact SQL the app would generate
+```text
+1. gallery_status
+2. cdp_console_logs
+3. cdp_evaluate
+4. cdp_screenshot
 ```
 
-## Other Available MCP Servers
+### 4. Deep database debugging (optional backend MCP)
 
-These servers are also configured and may be useful in conjunction:
+```text
+1. Enable imgscore-el-stdio or open backend workspace
+2. check_database_health
+3. query_images / get_image_details
+4. execute_sql if you need exact DB shape
+```
 
-| Server | Status | Purpose |
-|--------|--------|---------|
-| `git` | ✅ Enabled | Git operations on the `image-scoring` repo |
-| `filesystem` | ✅ Enabled | File access to `image-scoring`, `accounting`, `lightroom-mcp`, `sharp-image-scoring`, and Antigravity dirs |
-| `memory` | ✅ Enabled | Persistent key-value memory |
-| `fetch` | ✅ Enabled | HTTP fetch for external URLs |
-| `sqlite` | ✅ Enabled | SQLite for `accounting/finance.db` |
-| `moltbook` | ✅ Enabled | Social network for AI agents |
-| `lightroom` | ❌ Disabled | Lightroom integration |
-| `browsermcp` | ❌ Disabled | Browser automation |
-| `accounting-debugger` | ❌ Disabled | Accounting project debugging |
+For WebUI **`execute_code`**, add **`imgscore-el-sse`** when the WebUI runs (`ENABLE_MCP_EXECUTE_CODE=1` on the WebUI).

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "enableAllProjectMcpServers": true,
+  "disabledMcpjsonServers": [
+    "imgscore-el-playwright",
+    "imgscore-el-chrome-devtools"
+  ]
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,43 +1,9 @@
 {
-    "mcpServers": {
-        "imgscore-el-stdio": {
-            "command": "python",
-            "args": [
-                "-m",
-                "modules.mcp_server"
-            ],
-            "cwd": "d:\\Projects\\image-scoring-backend",
-            "env": {
-                "PYTHONPATH": "d:\\Projects\\image-scoring-backend"
-            }
-        },
-        "imgscore-el-sse": {
-            "url": "http://127.0.0.1:7860/mcp/sse",
-            "disabled": true
-        },
-        "imgscore-el-chrome-devtools": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "chrome-devtools-mcp",
-                "--browser-url=http://127.0.0.1:9222"
-            ],
-            "disabled": true
-        },
-        "imgscore-el-debug": {
-            "command": "node",
-            "args": [
-                "d:\\Projects\\image-scoring-gallery\\mcp-server\\dist\\index.js"
-            ],
-            "disabled": false
-        },
-        "imgscore-el-playwright": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "@playwright/mcp@latest"
-            ],
-            "disabled": true
-        }
+  "mcpServers": {
+    "imgscore-el-gallery": {
+      "command": "node",
+      "args": ["${workspaceFolder}/mcp-server/dist/index.js"],
+      "disabled": false
     }
+  }
 }

--- a/.cursor/rules/mcp-firebird.mdc
+++ b/.cursor/rules/mcp-firebird.mdc
@@ -67,3 +67,6 @@ alwaysApply: true
 
 Always present findings in a short markdown report, organized by these stages, and clearly distinguish *observations* from *risky actions* that require explicit user approval.
 
+## Related: mcp-kanban
+
+For **persistent tickets / kanban / multi-session handoffs** (user-level MCP **`mcp-kanban`**), see **`mcp-kanban.mdc`** and skill **`mcp-kanban-workflow`**.

--- a/.cursor/rules/mcp-kanban.mdc
+++ b/.cursor/rules/mcp-kanban.mdc
@@ -1,0 +1,36 @@
+---
+description: Use mcp-kanban MCP for task boards, tickets, and multi-session agent handoffs (Cursor, Claude Code, Antigravity)
+alwaysApply: false
+---
+
+# mcp-kanban MCP
+
+When the user asks about a **kanban board**, **MCP tickets**, **task queue**, **agent handoff**, **multi-agent coordination**, or **work items** that should persist across sessions, use the **`mcp-kanban`** MCP server.
+
+## Where it is configured
+
+| Client | Location |
+|--------|----------|
+| Cursor | User `mcp.json` (merges with this repo’s `.cursor/mcp.json`) |
+| Claude Code | User `~/.claude.json` → `mcpServers.mcp-kanban` |
+| Antigravity | `~/.gemini/antigravity/mcp_config.json` |
+| Codex | `~/.codex/config.toml` → `[mcp_servers.mcp-kanban]` |
+
+Server key name: **`mcp-kanban`**. Upstream repo: `D:\Projects\mcp-kanban`.
+
+## Tools (invoke via MCP)
+
+- **Scope:** `kanban_list_projects`, `kanban_register_project` (`projectFolder` = absolute path to **this** gallery repo or the backend repo, depending on where work lives)
+- **Tickets:** `kanban_create_ticket`, `kanban_list_tickets`, `kanban_get_ticket`, `kanban_pull_next_ticket`, `kanban_start_ticket`, `kanban_update_ticket`, `kanban_complete_ticket`, `kanban_add_ticket_relation`, `kanban_add_ticket_context`, `kanban_add_work_log`, `kanban_board_snapshot`
+
+## This workspace
+
+For **image-scoring-gallery** work, register and use **`D:\Projects\image-scoring-gallery`** as `projectFolder`. For Python backend work, use **`D:\Projects\image-scoring-backend`** (sibling path).
+
+**Key collision:** both folder names truncate to the same Kanban key prefix `IMAGE-SCORIN`. For tickets that span both repos, create them under **one** Kanban project (often the backend folder) and set `metadata.primaryRepo` to `image-scoring-gallery` when the work is gallery-only. See backend `.cursor/rules/mcp-kanban.mdc` for detail.
+
+## Workflows and troubleshooting
+
+Same patterns as the backend rule: register project → create/list/update tickets → work logs for handoffs. See **`D:\Projects\image-scoring-backend\.cursor\skills\mcp-kanban-workflow\SKILL.md`** (or the copy under this repo’s `.cursor/skills/`) for step-by-step flows.
+
+If kanban tools are missing from the tool list, confirm **`mcp-kanban`** is enabled in the user MCP config for your client.

--- a/.cursor/skills/mcp-kanban-workflow/SKILL.md
+++ b/.cursor/skills/mcp-kanban-workflow/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: mcp-kanban-workflow
+description: Coordinate multi-step or multi-session work with mcp-kanban tickets, board snapshots, and handoff logs. Trigger when the user asks for kanban, task board, MCP tickets, agent handoff, or persistent work queue.
+---
+
+# mcp-kanban workflow
+
+Same workflows as the Python backend skill: use MCP server **`mcp-kanban`** with **absolute** `projectFolder` values.
+
+## Project folders
+
+- **Gallery / Electron UI work:** `D:\Projects\image-scoring-gallery` (adjust if your clone path differs)
+- **Backend / API / ML work:** `D:\Projects\image-scoring-backend`
+
+Register each scope with `kanban_register_project` before creating tickets if it is not already listed in `kanban_list_projects`.
+
+## Steps
+
+1. **New task:** `kanban_register_project` (if needed) → `kanban_create_ticket`.
+2. **Handoff:** `kanban_list_tickets` → `kanban_get_ticket` → `kanban_add_work_log` / `kanban_update_ticket`.
+3. **Queue:** `kanban_pull_next_ticket` → `kanban_start_ticket` → complete or update.
+
+## References
+
+- Rule: `.cursor/rules/mcp-kanban.mdc`
+- Full step text and tool list: `D:\Projects\image-scoring-backend\.cursor\skills\mcp-kanban-workflow\SKILL.md` (canonical copy)
+- User MCP config must include **`mcp-kanban`** (Cursor / Claude / Antigravity / Codex)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,27 @@ This document describes the AI agent integration for the Electron Image Scoring 
 This project is optimized for AI-assisted development using Cursor IDE and Antigravity. It leverages MCP (Model Context Protocol) to provide agents with deep visibility into the shared scoring database.
 
 ## MCP Configuration
-The `.cursor/mcp.json` file uses the **`imgscore-el-*`** prefix so server names stay unique when Cursor merges multiple project configs. Image Scoring stdio is **`imgscore-el-stdio`** (sibling **image-scoring** repo). SSE for the Python WebUI is **`imgscore-el-sse`**. The Python repo defines **`imgscore-py-stdio`** / **`imgscore-py-sse`** for the same processes when that workspace is open.
+The `.cursor/mcp.json` file uses the **`imgscore-el-*`** prefix so server names stay unique when Cursor merges multiple project configs.
+
+**Primary (enabled): `imgscore-el-gallery`** — single stdio app from [`mcp-server/`](mcp-server/) (`node …/mcp-server/dist/index.js`). Always: logs, `config.json`, `get_system_stats`, **`gallery_status`** (probes FastAPI + Electron CDP). When the Python WebUI is up: **`api_*`** tools against the resolved backend URL. When Electron runs in dev with remote debugging: **`cdp_*`** tools (default CDP port 9222; set `ELECTRON_CDP_URL` or `ELECTRON_REMOTE_DEBUGGING_PORT` to match).
+
+**Opt-in: `imgscore-el-stdio`** — Python **`modules.mcp_server`** (full DB diagnostics, ~43 tools). **Disabled by default** in this repo; enable in MCP settings or open the **image-scoring-backend** workspace, which uses **`imgscore-py-stdio`**. **`imgscore-el-sse`** — WebUI SSE (e.g. `execute_code` when `ENABLE_MCP_EXECUTE_CODE=1`).
 
 ### Requirements
-- Python environment with `mcp` and `firebird-driver` (typically inherited from the core `image-scoring` project).
-- Access to the `SCORING_HISTORY.FDB` file.
+- **`imgscore-el-gallery`**: Node; run `npm install` and `npm run build` under `mcp-server/` once.
+- **Full DB MCP**: Python env with `mcp` (and DB drivers) when **`imgscore-el-stdio`** / backend workspace is enabled.
+- Access to the `SCORING_HISTORY.FDB` file for the Electron app itself.
 
 ## Tools for Agents
-Agents have access to specialized tools via **`imgscore-el-stdio`** (stdio) and **`imgscore-el-sse`** (when the WebUI runs). Other entries: **`imgscore-el-firebird`**, **`imgscore-el-playwright`**, **`imgscore-el-chrome-devtools`**, **`imgscore-el-debug`**.
-- **Database Analysis**: Query images, check health, run SQL.
-- **System Monitoring**: Check GPU and model status.
-- **Error Diagnosis**: Analyze failed jobs and missing data.
+- **Gallery MCP (`imgscore-el-gallery`)**: Local diagnostics, optional FastAPI job/health probes, optional CDP for renderer inspection. Start with **`gallery_status`** to see what is reachable.
+- **Python MCP (optional)**: Query images, `execute_sql`, health, jobs — see backend **`AGENTS.md`** / **`imgscore-py-stdio`**.
+
+### mcp-kanban (optional, user MCP)
+
+**mcp-kanban** is configured in **user-level** MCP settings (Cursor global `mcp.json`, Claude `~/.claude.json`, Antigravity `mcp_config.json`, Codex `config.toml`) as server **`mcp-kanban`**. It provides **`kanban_*`** tools for tickets, board snapshots, and session handoffs.
+
+- **Rules / workflow:** `.cursor/rules/mcp-kanban.mdc`, `.cursor/skills/mcp-kanban-workflow/SKILL.md`
+- **Project folder:** use **`D:\Projects\image-scoring-gallery`** for gallery work and **`D:\Projects\image-scoring-backend`** for backend work (adjust paths if your clones differ).
 
 ## Documentation References
 - **[Agent Coordination](docs/technical/AGENT_COORDINATION.md)** - Cross-project integration and coordination guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,20 @@ High-performance Electron desktop gallery app with image scoring, browsing, and 
 
 The backend owns all DDL/schema migrations (`modules/db.py`). This project queries the shared Firebird database but does NOT create or alter tables (except `STACK_CACHE` probe).
 
+## MCP mcp-kanban (optional, user-level)
+
+**mcp-kanban** provides SQLite-backed **tickets / kanban** for multi-session work. Configure it in **user** MCP settings (Cursor, Claude Code, Antigravity, Codex) as server **`mcp-kanban`**—see `.cursor/rules/mcp-kanban.mdc` and `.cursor/skills/mcp-kanban-workflow/SKILL.md`.
+
+- Register this repo with `kanban_register_project` using **`D:\Projects\image-scoring-gallery`** (or your clone path) as `projectFolder`.
+- Use **`D:\Projects\image-scoring-backend`** as `projectFolder` for backend-only tasks.
+
 ## Key Files
 
 - `electron/db.ts` — Firebird query layer (single-connection promise queue)
 - `electron/main.ts` — Electron main process, IPC handlers
 - `electron/apiService.ts` — HTTP client to Python FastAPI backend
 - `src/` — React frontend (Vite + TypeScript)
-- `mcp-server/` — MCP server for AI agent debugging
+- `mcp-server/` — Consolidated stdio MCP (`imgscore-el-gallery`): local tools, optional FastAPI + Electron CDP
 
 ## Backend Integration Points
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Project-level task list. Items marked `[Python]`, `[Gradio]`, or `[DB]` involve 
 
 > **Source of truth & update order:** This file is the canonical task ledger (owner: Electron maintainers). Update this file first, then sync `docs/planning/01-roadmap-todo.md`, then `docs/integration/TODO.md`, and finally `docs/features/planned/embeddings/TODO.md`.
 
-Last evaluated: 2026-03-28.
+Last evaluated: 2026-04-01.
 
 | Marker | Use when |
 |--------|----------|
@@ -32,21 +32,21 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 
 ---
 
-## Unfinished Business Evaluation (2026-03-14)
+## Unfinished Business Evaluation (2026-04-01)
 
 ### Current Status Snapshot
 
-- **Total open items**: 18
-- **Electron-only (unblocked) items**: 4
-- **Cross-repo dependency items** (`[Python]`, `[Gradio]`, `[DB]`, `[DB+Python]`): 14
+- **Total open items**: 14
+- **Electron-only (unblocked) items**: 1
+- **Cross-repo dependency items** (`[Python]`, `[Gradio]`, `[DB]`, `[DB+Python]`): 13
 
 ### Highest-Impact Next Steps (Recommended Sequence)
 
-1. **[EIS-101](docs/planning/03-high-impact-tracked-tasks.md#eis-101---harden-useimages-data-loading-race-safety) - Harden data-loading race safety in `useImages`** (request token / in-flight guard) to reduce duplicate pagination fetches and stale UI updates.
-2. **[EIS-102](docs/planning/03-high-impact-tracked-tasks.md#eis-102---stabilize-runtime-observability) - Stabilize runtime observability** (log rotation/retention + bounded WebSocket reconnect policy) to keep long-running sessions predictable.
-3. **[EIS-103](docs/planning/03-high-impact-tracked-tasks.md#eis-103---decompose-appcontenttsx--styling-strategy-alignment) - Decompose `AppContent.tsx` and align styling strategy** to lower feature-delivery friction before adding more embedding UI surfaces.
-4. **[EIS-104](docs/planning/03-high-impact-tracked-tasks.md#eis-104---close-local-quality-debt-prior-to-backend-expansion) - Close remaining local quality debt** (`no-explicit-any`, `useImages`/`useStacks` closure and dependency issues) so future backend integrations are lower-risk.
-5. **[EIS-105](docs/planning/03-high-impact-tracked-tasks.md#eis-105---execute-embedding-feature-wave-with-backend-coordination) - Execute embedding feature wave with backend coordination** (Tag Propagation → Outlier Detection → 2D Map → Smart Stack Representative).
+1. **[EIS-105](docs/planning/03-high-impact-tracked-tasks.md#eis-105---execute-embedding-feature-wave-with-backend-coordination) - Execute embedding feature wave with backend coordination** (Tag Propagation → Outlier Detection → 2D Map → Smart Stack Representative).
+2. **Consolidate styling into a unified system** (CSS Modules or Tailwind) to reduce UI churn after the `AppContent.tsx` decomposition.
+3. **Tighten backend integration hygiene** by keeping `electron/apiTypes.ts` aligned with backend contract changes and adding similarity IPC handlers as backend endpoints land.
+4. **Plan the Firebird→Postgres provider transition** (provider abstraction, client cutover, and removal of Firebird-only runtime assumptions) before deeper backend expansion.
+5. ~~**[EIS-104](docs/planning/03-high-impact-tracked-tasks.md#eis-104---close-local-quality-debt-prior-to-backend-expansion) - Close local quality debt**~~ — done (2026-04-01).
 
 ### Dependency Notes
 
@@ -65,6 +65,9 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 - [x] [EIS-101] Harden `useImages` / `useStacks` data-loading race safety (stable func refs, loadMore stability, filterKey, race tests)
 - [x] [EIS-102] Stabilize runtime observability (log rotation/retention via `sessionLogManager.ts` + bounded WebSocket reconnect with exponential backoff, jitter, 50-attempt cap)
 - [x] [EIS-103] Decompose `AppContent.tsx` into domain hooks: `useElectronListeners`, `useGalleryNavigation`, `useStacksMode`, `useImageOpener`, `useGalleryWebSocket` (864 → 449 lines)
+- [x] Expand MCP server tooling scope: consolidated `imgscore-el-gallery`, `gallery_status`, optional FastAPI probes (`api_*`), and optional Electron CDP tools (`cdp_*`)
+- [x] [EIS-104] Close local quality debt: typed diagnostics (`DiagnosticsReport` / `ProcessMemorySnapshot`), RunsPage `input_path`, `apiClient` `window.electron`, `useFolders` deferred mount fetch + `useCallback`
+- [x] Document `config.api.url` / `config.api.port` behavior in user-facing docs (`docs/guides/02-api-backend-config.md`)
 
 ---
 
@@ -88,7 +91,7 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 ## P3 - Lower Priority
 
 - [ ] Refactor folder lookup to indexed structure in `useFolders` [DB]
-- [ ] Cleanup remaining lint/type warnings (`no-explicit-any`)
+- [x] Cleanup high-impact production `no-explicit-any` / hook smell in paths touched for EIS-104 (full-repo ESLint baseline still includes test mocks and other files)
 - [ ] **2D Embedding Map** [Python]: Create `EmbeddingMap.tsx`, WebGL visualization of 1280-d vectors projected to 2D, add navigation to map view in `AppContent.tsx`
 - [ ] **Outlier Detection** UI [Python]: Add "Show Outliers" toggle to `FilterPanel.tsx`, visual badge in `GalleryGrid.tsx`, connect to backend outlier detection endpoint
 - [ ] **Smart Stack Representative** [Python]: Add "Smart Cover" toggle to `SelectionSettings.tsx`, implement centroid-based cover selection in IPC/Backend
@@ -101,7 +104,7 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 - [x] [Gradio] Subscribe to `job_progress` for live progress bar (`src/hooks/useGalleryWebSocket.ts` `subscribe('job_progress', ...)`, rendered via `src/components/Layout/JobProgressBar.tsx`, state in `src/store/useJobProgressStore.ts`)
 - [ ] [Python] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
 - [ ] [Python] Sync `electron/apiTypes.ts` when backend API contract changes
-- [ ] Document `config.api.url` / `config.api.port` override in user-facing docs
+- [x] Document `config.api.url` / `config.api.port` override in user-facing docs
 - [x] [Python] Ensure `image_updated` and `folder_updated` handlers refresh correct views
 
 ---
@@ -119,7 +122,7 @@ Use these rules whenever reporting counts in this file (or in linked planning do
 
 - [x] Unbounded WebSocket reconnection backoff: add max retries, exponential backoff, connection jitter
 - [x] Race conditions in `useImages` / `useStacks`: fix closure capture in `loadMore()`, `JSON.stringify` deps in `useEffect`
-- [ ] MCP server: expand tooling scope (DB query tools, image caching controls)
+- [x] MCP server: expand tooling scope (`gallery_status`, optional FastAPI probes, optional Electron CDP tools)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ API and backend integration documentation.
 Development workflows and maintenance recommendations.
 
 - [01 - Lint Recommendations](guides/01-lint-recommendations.md) - Code quality and ESLint fix guidance
+- [02 - API Backend Configuration](guides/02-api-backend-config.md) - How `config.api.url` / `host` / `port` interact with backend lock-file discovery
 - [Agent Coordination](https://github.com/synthet/image-scoring-backend/blob/main/docs/technical/AGENT_COORDINATION.md) - Cross-project integration and coordination protocols (External)
 
 ---

--- a/docs/guides/02-api-backend-config.md
+++ b/docs/guides/02-api-backend-config.md
@@ -1,0 +1,58 @@
+# API Backend Configuration
+
+This gallery can discover the Python backend automatically, but you can also pin or redirect it with `config.json`.
+
+## Resolution Order
+
+The backend base URL is resolved in this order:
+
+1. **`config.api.url`**: exact base URL, highest priority
+2. **Sibling backend lock file**: `webui.lock` / `webui-debug.lock` from `image-scoring-backend` or legacy `image-scoring`
+3. **Fallback host/port**: `config.api.host` + `config.api.port`
+4. **Default fallback**: `http://127.0.0.1:7860`
+
+## When To Use Which Setting
+
+- Use **`config.api.url`** when you want a hard override and do not want lock-file discovery to change the target.
+- Use **`config.api.host`** and **`config.api.port`** when you want to change the fallback target used when no sibling backend lock file is present.
+- Leave all three unset when the backend repo is a sibling checkout and writes `webui.lock` normally.
+
+## Example
+
+```json
+{
+  "api": {
+    "url": "http://192.168.1.50:7860"
+  }
+}
+```
+
+Hard override with exact URL:
+
+- Always uses `http://192.168.1.50:7860`
+- Ignores sibling `webui.lock` port discovery
+
+```json
+{
+  "api": {
+    "host": "127.0.0.1",
+    "port": 9000
+  }
+}
+```
+
+Fallback host/port:
+
+- Uses `http://127.0.0.1:9000` only when no sibling backend lock file is found
+- If a sibling backend lock file exists, the discovered port still wins
+
+## Expected Project Layout
+
+Automatic lock-file discovery checks these sibling locations relative to the gallery repo:
+
+- `../image-scoring-backend/webui.lock`
+- `../image-scoring-backend/webui-debug.lock`
+- `../image-scoring/webui.lock`
+- `../image-scoring/webui-debug.lock`
+
+This supports the current `image-scoring-backend` repo name and the older `image-scoring` layout.

--- a/docs/integration/TODO.md
+++ b/docs/integration/TODO.md
@@ -16,5 +16,5 @@ Tasks for Electron ↔ Python backend integration. See [Agent Coordination](http
 
 ## Configuration
 
-- [ ] Document `config.api.url` / `config.api.port` override in user-facing docs
-- [ ] Project layout (sibling `image-scoring` / `image-scoring-gallery`) documented in CLAUDE.md
+- [x] Document `config.api.url` / `config.api.port` override in user-facing docs (`docs/guides/02-api-backend-config.md`)
+- [x] Project layout (sibling `image-scoring` / `image-scoring-gallery`) documented in CLAUDE.md

--- a/docs/planning/01-roadmap-todo.md
+++ b/docs/planning/01-roadmap-todo.md
@@ -1,64 +1,67 @@
 # TODO - Electron Image Scoring
 
-Consolidated list of unfinished work items. Last Updated: Mar 28, 2026.
+Consolidated list of unfinished work items. Last Updated: Apr 1, 2026.
 
 > **Source of truth & update order:** Secondary roadmap mirror (owner: planning/docs maintainers). Sync only after `TODO.md`, then reconcile this file before updating `docs/integration/TODO.md` and `docs/features/planned/embeddings/TODO.md`.
 
 ---
 
-## Count Snapshot Rules (Shared with `TODO.md`)
+## Snapshot
 
-Use these rules for any count snapshots in this document:
+- **Total open items**: 14
+- **Electron-only items**: 1
+- **Cross-repo dependency items** (`[Python]`, `[Gradio]`, `[DB]`, `[DB+Python]`): 13
 
-- **What counts as “open”**: any unchecked checkbox line (`- [ ] ...`) counts as one open item.
-- **How grouped checklist items are counted**: each unchecked checkbox line counts independently. If a parent has its own checkbox and child checkboxes, count all unchecked lines (parent + each child).
-- **Cross-repo markers**: any open item containing `[Python]`, `[Gradio]`, `[DB]`, or `[DB+Python]` is counted as a **cross-repo dependency item**.
-  - Items with none of those markers are counted as **Electron-only**.
-  - `[DB+Python]` is a single cross-repo class (do not double-count it as both `[DB]` and `[Python]`).
+### Highest-Impact Next Steps
 
-### Compact Counting Example (from `P1 (High Priority)`)
-
-- Open items in this section: **4** (Gradio Pipeline + Embedding parent + 2 child items; request token/Vitest/handlers complete)
-- Cross-repo items: **3** (Embedding parent + 2 children with `[Python]`)
-- Electron-only items: **1** (Gradio Pipeline)
-- Check: `open (4) = cross-repo (3) + Electron-only (1)`
+1. **[EIS-105](03-high-impact-tracked-tasks.md#eis-105---execute-embedding-feature-wave-with-backend-coordination)** Deliver the embedding feature wave in backend-ready order.
+2. **Consolidate styling into a unified system** so the post-`AppContent.tsx` architecture has a stable UI direction.
+3. **Tighten backend integration hygiene** by syncing `electron/apiTypes.ts` with backend changes and adding similarity IPC handlers as backend endpoints land.
+4. **Plan Firebird→Postgres provider transition** before expanding deeper backend integration.
+5. ~~**[EIS-104](03-high-impact-tracked-tasks.md#eis-104---close-local-quality-debt-prior-to-backend-expansion)**~~ — done (2026-04-01).
 
 ---
 
-## ✅ Completed (Recently)
+## Recently Completed
 
 - [x] Harden `media://` path validation (traversal protection)
 - [x] Implement Database Connection Pooling (`electron/db.ts`)
 - [x] Scale protection for `useImages` (2000 item limit + pagination)
-- [x] Standardized IPC error handling envelope `{ ok, data, error }`
-- [x] Efficient NEF buffer serialization (native Buffer passing)
-- [x] Implement global React Error Boundary (`src/main.tsx`)
-- [x] Patched `node-firebird` crash & added `postinstall` safeguard
-- [x] Initial Image Import UI with deduplication (`ImportModal.tsx`)
 - [x] Centralized REST API client for Python backend (`ApiService.ts`)
+- [x] [EIS-101] Harden `useImages` / `useStacks` data-loading race safety
+- [x] [EIS-102] Stabilize runtime observability (log rotation/retention + bounded WebSocket reconnect)
+- [x] [EIS-103] Decompose `AppContent.tsx` into domain hooks and reduce orchestration complexity
+- [x] Expand MCP server tooling scope: consolidated `imgscore-el-gallery`, `gallery_status`, optional FastAPI probes, and optional Electron CDP tools
+- [x] [EIS-104] Close local quality debt (see `03-high-impact-tracked-tasks.md`)
+- [x] Document `config.api.url` / `config.api.port` behavior in user-facing docs
 
-## P1 (High Priority)
+## P1 - High Priority
 
-- [ ] Migrate Gradio Pipeline UI into Electron **Processing** workspace (menu entry, phase controls, logs, queue status)
-- [ ] **Embedding Feature Integration** [Python]:
-    - [ ] Add "Find Similar" to context menu and details panel
-    - [ ] Integrate "Duplicate Finder" into main navigation
-- [x] Add explicit request token / in-flight guard to `useImages` for pagination races
-- [x] Setup `Vitest` and basic test coverage for hooks/services
-- [x] Ensure `image_updated` and `folder_updated` handlers refresh correct views
-- [x] Subscribe to `job_progress` for live progress updates (`src/hooks/useGalleryWebSocket.ts` `subscribe('job_progress', ...)`, `src/components/Layout/JobProgressBar.tsx`, `src/store/useJobProgressStore.ts`)
+- [ ] **Embedding feature integration** [Python]: Add "Find Similar" to context menu and details panel; integrate "Duplicate Finder" into main navigation
 
-## P2 (Medium Priority)
+## P2 - Medium Priority
 
-- [ ] Add log rotation and retention for session logs
-- [ ] Further decompose `AppContent.tsx` into modular domain hooks/components
 - [ ] Consolidate styling into a unified system (CSS Modules or Tailwind)
-- [ ] Implement semantic "Tag Propagation" UI from similar images
+- [ ] Implement semantic **Tag Propagation** UI [Python]
 
-## P3 (Lower Priority)
+## P3 - Lower Priority
 
-- [ ] Refactor folder lookup to indexed structure in `useFolders`
-- [ ] Cleanup remaining lint/type warnings (`no-explicit-any`)
-- [ ] 2D Embedding Map (WebGL visualization)
-- [ ] Outlier Detection UI
-- [ ] Smart Stack Representative
+- [ ] Refactor folder lookup to indexed structure in `useFolders` [DB]
+- [x] Cleanup high-impact production `no-explicit-any` / hook smell (EIS-104); broader ESLint baseline still open
+- [ ] **2D Embedding Map** [Python]
+- [ ] **Outlier Detection** UI [Python]
+- [ ] **Smart Stack Representative** [Python]
+
+## Python / Backend Integration
+
+- [ ] [Gradio] Enhance IPC/WebSocket bridge for real-time AI updates with the Python backend
+- [ ] [Python] Add IPC handlers for new similarity endpoints when backend exposes them (`/api/similarity/*`)
+- [ ] [Python] Sync `electron/apiTypes.ts` when backend API contract changes
+- [x] Document `config.api.url` / `config.api.port` override in user-facing docs
+
+## Database & Migration
+
+- [ ] [DB] Evaluate replacement for outdated `node-firebird` driver
+- [ ] [DB+Python] Add DB provider abstraction in `electron/db.ts` for Postgres
+- [ ] [DB+Python] Migrate Electron from `node-firebird` to Postgres client after Python cutover
+- [ ] [DB+Python] Remove Firebird-specific runtime assumptions

--- a/docs/planning/03-high-impact-tracked-tasks.md
+++ b/docs/planning/03-high-impact-tracked-tasks.md
@@ -90,10 +90,18 @@ These tracked tasks are the auditable execution records for the five highest-imp
   - [x] Build/tests pass with no regressions in core gallery workflows (`npx tsc --noEmit` clean).
   - [x] TODO references updated with completion status.
 
-## EIS-104 - Close local quality debt prior to backend expansion
+## EIS-104 - Close local quality debt prior to backend expansion ✅ DONE (2026-04-01)
 
 - **Source item**: "Close remaining local quality debt (`no-explicit-any`, `useImages`/`useStacks` closure and dependency issues)"
 - **Suggested owner/team**: Electron Frontend Quality
+- **Completed**: 2026-04-01
+- **Changes made**:
+  - `src/electron.d.ts` — Exported `DiagnosticsReport` and `ProcessMemorySnapshot`; `getDiagnostics` / `getProcessMemoryInfo` return types reference them.
+  - `src/components/Diagnostics/DiagnosticsModal.tsx` — Typed diagnostic state; `catch (err: unknown)` with `instanceof Error` narrowing.
+  - `src/components/Runs/RunsPage.tsx` — Use `job.input_path` on `BackendJobInfo` (removed `as any`); fixed unused destructuring binding in pipeline operations filter.
+  - `src/services/apiClient.ts` — Use typed `window.electron` for `getApiPort` (no `as any`).
+  - `src/hooks/useFolders.ts` — Initial load via `queueMicrotask` + stable `fetchFolders` (`useCallback`) to avoid synchronous `set-state-in-effect`; removed prior eslint-disable.
+  - **Note:** `useImages` / `usePaginatedData` / `useStacks` already had no `any` and EIS-101 race hardening; full-repo ESLint still reports unrelated baseline issues (tests, other components).
 - **Scope boundaries**:
   - In scope:
     - Eliminate remaining high-impact `no-explicit-any` warnings in active app code.
@@ -106,10 +114,10 @@ These tracked tasks are the auditable execution records for the five highest-imp
   - Backend: None required.
   - Migration: None.
 - **Definition of done**:
-  - Targeted lint/type debt list for this item is fully closed.
-  - Hook dependency/closure fixes are covered by tests or deterministic reproduction checks.
-  - CI/local lint pipeline passes for touched scope.
-  - TODO references updated with completion status.
+  - [x] Targeted lint/type debt list for this item is fully closed (touched production files clean under ESLint; `npx tsc --noEmit` clean).
+  - [x] Hook dependency/closure fixes are covered by tests or deterministic reproduction checks (`useFolders` mount path; existing `useImages` race tests unchanged).
+  - [x] CI/local lint pipeline passes for touched scope.
+  - [x] TODO references updated with completion status.
 
 ## EIS-105 - Execute embedding feature wave with backend coordination
 

--- a/docs/reports/01-code-design-review-2026-03.md
+++ b/docs/reports/01-code-design-review-2026-03.md
@@ -174,13 +174,13 @@ The following findings have been implemented and verified (TypeScript compilatio
 | 12 | Path Traversal Risk | Medium | **Resolved** | `electron/main.ts` |
 | 13 | Duplicate Hook Logic | Medium | **Resolved** | `src/hooks/useDatabase.ts` |
 | 14 | Missing Error Boundaries | Medium | **Resolved** | `src/components/ErrorBoundary.tsx`, `src/main.tsx` |
-| 15 | Minimal MCP Scope | Low | Deferred | — |
+| 15 | Minimal MCP Scope | Low | **Resolved** | `mcp-server/src/index.ts`, `mcp-server/src/tools/api.ts`, `mcp-server/src/tools/cdp.ts`, `mcp-server/src/utils/capabilities.ts`, `mcp-server/src/utils/cdp.ts` |
 | 16 | Outdated DB Driver | Low | Deferred | — |
 | 17 | Loading/Empty States | Low | Deferred | — |
 
 ### Changes Summary
 
-**11 of 17 findings resolved. 6 deferred for separate work.**
+**12 of 17 findings resolved. 5 deferred for separate work.**
 
 #### `electron/db.ts` — Persistent Connection
 - Replaced per-query `Firebird.attach()` with a `getConnection()` singleton
@@ -220,6 +220,12 @@ The following findings have been implemented and verified (TypeScript compilatio
 - Updated `extractNefPreview` buffer type from `number[]` to `Uint8Array`
 - Removed duplicate property definitions
 
+#### `mcp-server/` — Consolidated gallery MCP
+- Renamed the gallery MCP package/server to reflect its broader scope (`imgscore-el-gallery`)
+- Added `gallery_status` to probe FastAPI and Electron CDP reachability before choosing tool families
+- Added reachability-aware FastAPI probe tools (`api_*`) and Electron CDP tools (`cdp_*`)
+- Added configurable CDP endpoint resolution via `ELECTRON_CDP_URL` / `ELECTRON_REMOTE_DEBUGGING_PORT`
+
 ### Deferred Items
 
 | # | Finding | Reason |
@@ -228,7 +234,6 @@ The following findings have been implemented and verified (TypeScript compilatio
 | 5 | Testing Infrastructure | Deserves dedicated task with Vitest setup |
 | 10 | Design System / CSS | Large UI refactor requiring design decisions |
 | 11 | Prop Drilling | Depends on App.tsx decomposition (#3) |
-| 15 | MCP Server Scope | Separate feature work, low severity |
 | 16 | DB Driver Upgrade | Risky dependency swap, requires migration plan |
 | 17 | Loading/Empty States | UI polish pass, low severity |
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -641,26 +641,14 @@ export async function getOrCreateFolder(folderPath: string): Promise<number> {
         }
     }
 
-    try {
-        const insertResult = await query<{ id: number }>(
-            'INSERT INTO folders (path, parent_id, is_fully_scored, created_at) VALUES (?, ?, 0, CURRENT_TIMESTAMP) RETURNING id',
-            [normalized, parentId]
-        );
-        if (insertResult.length > 0) {
-            return insertResult[0].id;
-        }
-    } catch (e) {
-        const errStr = String(e);
-        if (errStr.includes('RETURNING') || errStr.includes('syntax')) {
-            await query('INSERT INTO folders (path, parent_id, is_fully_scored, created_at) VALUES (?, ?, 0, CURRENT_TIMESTAMP)', [normalized, parentId]);
-            const rows = await query<{ id: number }>('SELECT id FROM folders WHERE path = ?', [normalized]);
-            if (rows.length > 0) return rows[0].id;
-        }
-        throw e;
+    const insertResult = await query<{ id: number }>(
+        'INSERT INTO folders (path, parent_id, is_fully_scored, created_at) VALUES (?, ?, 0, CURRENT_TIMESTAMP) RETURNING id',
+        [normalized, parentId]
+    );
+    if (insertResult.length > 0) {
+        return insertResult[0].id;
     }
 
-    const rows = await query<{ id: number }>('SELECT id FROM folders WHERE path = ?', [normalized]);
-    if (rows.length > 0) return rows[0].id;
     throw new Error(`Failed to get folder id for path: ${normalized}`);
 }
 
@@ -696,29 +684,14 @@ export async function insertImage(row: InsertImageRow): Promise<number> {
     const normalizedPath = normalizePathForDb(row.file_path);
     const uuid = row.image_uuid ?? null;
 
-    try {
-        const insertResult = await query<{ id: number }>(
-            'INSERT INTO images (file_path, file_name, file_type, folder_id, image_uuid, created_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP) RETURNING id',
-            [normalizedPath, row.file_name, row.file_type, row.folder_id, uuid]
-        );
-        if (insertResult.length > 0) {
-            return insertResult[0].id;
-        }
-    } catch (e) {
-        const errStr = String(e);
-        if (errStr.includes('RETURNING') || errStr.includes('syntax')) {
-            await query(
-                'INSERT INTO images (file_path, file_name, file_type, folder_id, image_uuid, created_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)',
-                [normalizedPath, row.file_name, row.file_type, row.folder_id, uuid]
-            );
-            const rows = await query<{ id: number }>('SELECT id FROM images WHERE file_path = ? ORDER BY id DESC', [normalizedPath]);
-            if (rows.length > 0) return rows[0].id;
-        }
-        throw e;
+    const insertResult = await query<{ id: number }>(
+        'INSERT INTO images (file_path, file_name, file_type, folder_id, image_uuid, created_at) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP) RETURNING id',
+        [normalizedPath, row.file_name, row.file_type, row.folder_id, uuid]
+    );
+    if (insertResult.length > 0) {
+        return insertResult[0].id;
     }
 
-    const rows = await query<{ id: number }>('SELECT id FROM images WHERE file_path = ? ORDER BY id DESC', [normalizedPath]);
-    if (rows.length > 0) return rows[0].id;
     throw new Error(`Failed to get image id after insert: ${normalizedPath}`);
 }
 
@@ -771,23 +744,12 @@ export async function syncImageKeywords(imageId: number, keywordsStr: string | n
             if (existing.length > 0) {
                 kwId = existing[0].keyword_id;
             } else {
-                try {
-                    const insertResult = await query<{ keyword_id: number }>(
-                        'INSERT INTO keywords_dim (keyword_norm, keyword_display) VALUES (?, ?) RETURNING keyword_id',
-                        [kwNorm, kw]
-                    );
-                    if (insertResult.length > 0) {
-                        kwId = insertResult[0].keyword_id;
-                    }
-                } catch (e) {
-                    const errStr = String(e);
-                    if (errStr.includes('RETURNING') || errStr.includes('syntax')) {
-                        await query('INSERT INTO keywords_dim (keyword_norm, keyword_display) VALUES (?, ?)', [kwNorm, kw]);
-                        const rows = await query<{ keyword_id: number }>('SELECT keyword_id FROM keywords_dim WHERE keyword_norm = ?', [kwNorm]);
-                        if (rows.length > 0) kwId = rows[0].keyword_id;
-                    } else {
-                        throw e;
-                    }
+                const insertResult = await query<{ keyword_id: number }>(
+                    'INSERT INTO keywords_dim (keyword_norm, keyword_display) VALUES (?, ?) RETURNING keyword_id',
+                    [kwNorm, kw]
+                );
+                if (insertResult.length > 0) {
+                    kwId = insertResult[0].keyword_id;
                 }
             }
             
@@ -855,7 +817,7 @@ export async function ensureStackCacheTable(): Promise<void> {
                 console.log('[DB] Created stack_cache table');
             } catch (e2) {
                 const errStr = String(e2);
-                if (errStr.includes('RDB$RELATION_NAME') || errStr.includes('exists')) {
+                if (errStr.includes('already exists') || errStr.includes('exists')) {
                     console.log('[DB] stack_cache table already exists (race condition ignored)');
                 } else {
                     console.error('[DB] Failed to create stack_cache table:', e2);

--- a/electron/db/provider.test.ts
+++ b/electron/db/provider.test.ts
@@ -47,18 +47,16 @@ describe('Database Connector Abstraction', () => {
             expect(connector.type).toBe('api');
         });
 
-        it('should create a PostgresConnector for legacy firebird engine config', () => {
+        it('should throw error for decommissioned "firebird" engine', () => {
             const config = {
                 dbConfig: { 
                     engine: 'firebird',
                     postgres: { host: 'localhost', port: 5432, database: 'test', user: 'user' }
                 },
             };
-            const connector = createDatabaseConnector(
+            expect(() => createDatabaseConnector(
                 config as { dbConfig: DatabaseConfig }
-            );
-            expect(connector).toBeInstanceOf(PostgresConnector);
-            expect(connector.type).toBe('postgres');
+            )).toThrow('[DB] Unsupported database engine: firebird');
         });
 
         it('should create a PostgresConnector when engine is "postgres"', () => {

--- a/electron/db/provider.ts
+++ b/electron/db/provider.ts
@@ -318,8 +318,7 @@ export function createDatabaseConnector(config: {
         return new ApiConnector(url, timeout);
     }
 
-    if (kind === 'postgres' || kind === 'postgresql' || kind === 'firebird') {
-        // Legacy 'firebird' engine value maps to Postgres (Firebird has been decommissioned)
+    if (kind === 'postgres' || kind === 'postgresql') {
         const pgCfg = 'postgres' in config.dbConfig ? config.dbConfig.postgres : undefined;
         if (!pgCfg) {
             throw new Error('[DB] database.postgres config is required.');

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "electron-debug-mcp",
-    "version": "1.0.0",
+    "name": "image-scoring-gallery-mcp",
+    "version": "2.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "electron-debug-mcp",
-            "version": "1.0.0",
+            "name": "image-scoring-gallery-mcp",
+            "version": "2.1.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.1"
             },

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "electron-debug-mcp",
-    "version": "1.0.0",
-    "description": "MCP server for debugging image-scoring-gallery",
+    "name": "image-scoring-gallery-mcp",
+    "version": "2.1.0",
+    "description": "Consolidated stdio MCP for image-scoring-gallery (local tools, optional FastAPI + Electron CDP)",
     "main": "dist/index.js",
     "type": "module",
     "scripts": {

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import fs from "fs/promises";
 import path from "path";
 import os from "os";
 
+import { collectGalleryStatus } from "./utils/capabilities.js";
 import { readConfig, getConfigPath } from "./utils/config.js";
 import { apiToolDefs, handleApiTool } from "./tools/api.js";
 import { cdpToolDefs, handleCdpTool } from "./tools/cdp.js";
@@ -16,8 +17,8 @@ import { cdpToolDefs, handleCdpTool } from "./tools/cdp.js";
 // Initialize server
 const server = new Server(
     {
-        name: "electron-debug-server",
-        version: "2.0.0",
+        name: "image-scoring-gallery",
+        version: "2.1.0",
     },
     {
         capabilities: {
@@ -70,7 +71,16 @@ const coreToolDefs = [
     },
     {
         name: "get_system_stats",
-        description: "Get system stats (CPU, memory, uptime) and detect running Electron/Python processes.",
+        description: "Get system stats (CPU, memory, uptime). Does not probe network; use gallery_status for API/CDP reachability.",
+        inputSchema: {
+            type: "object" as const,
+            properties: {},
+        },
+    },
+    {
+        name: "gallery_status",
+        description:
+            "Probe capabilities: python_api (FastAPI /api/health via resolved backend URL) and electron_cdp (DevTools /json). Use first to see whether api_* vs cdp_* tools are likely to work.",
         inputSchema: {
             type: "object" as const,
             properties: {},
@@ -126,6 +136,11 @@ async function handleCoreTool(name: string, args: Record<string, unknown>): Prom
         return { content: [{ type: "text", text: JSON.stringify(stats, null, 2) }] };
     }
 
+    if (name === "gallery_status") {
+        const status = await collectGalleryStatus();
+        return { content: [{ type: "text", text: JSON.stringify(status, null, 2) }] };
+    }
+
     throw new Error(`Unknown core tool: ${name}`);
 }
 
@@ -152,7 +167,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    console.error("Electron Debug MCP Server v2.0 running on stdio");
+    console.error("image-scoring-gallery MCP (stdio) v2.1.0");
     console.error(`Tools: ${[...coreToolDefs, ...apiToolDefs, ...cdpToolDefs].map(t => t.name).join(", ")}`);
 }
 

--- a/mcp-server/src/tools/api.ts
+++ b/mcp-server/src/tools/api.ts
@@ -34,13 +34,13 @@ export const apiToolDefs: ToolDef[] = [
     {
         name: "api_health",
         description:
-            "Check if the Python scoring backend (FastAPI) is running. Returns health status, loaded models, and GPU availability.",
+            "Requires python_api reachable (see gallery_status). Check FastAPI: health + status payloads (models, GPU).",
         inputSchema: { type: "object", properties: {} },
     },
     {
         name: "api_job_status",
         description:
-            "Get recent background jobs or one job by id. job_id is the integer jobs.id — the same as workflow run_id used in POST/GET /api/runs/{run_id}/... (e.g. GET /api/jobs/296 for run 296).",
+            "Requires python_api. Recent jobs or one job: job_id is jobs.id / workflow run_id (e.g. GET /api/jobs/296).",
         inputSchema: {
             type: "object",
             properties: {
@@ -55,7 +55,7 @@ export const apiToolDefs: ToolDef[] = [
     {
         name: "api_run_stages",
         description:
-            "GET /api/runs/{run_id}/stages — all pipeline stages for a workflow run (same id as jobs.id / api_job_status job_id).",
+            "Requires python_api. GET /api/runs/{run_id}/stages — pipeline stages (run_id = jobs.id).",
         inputSchema: {
             type: "object",
             properties: {
@@ -70,7 +70,7 @@ export const apiToolDefs: ToolDef[] = [
     {
         name: "api_probe",
         description:
-            "GET a relative path on the scoring WebUI (same base URL as other API tools) and return status, elapsed ms, and a short body preview. Use for slow endpoints (e.g. /api/scope/tree). path must start with / and must not contain ..",
+            "Requires python_api. Timed GET on backend base URL; status, elapsed_ms, body preview. path must start with /, no ..",
         inputSchema: {
             type: "object",
             properties: {
@@ -89,7 +89,7 @@ export const apiToolDefs: ToolDef[] = [
     {
         name: "api_runner_status",
         description:
-            "Get the current status of all background runners (scoring, tagging, clustering) — whether they are idle, running, or errored, and their progress.",
+            "Requires python_api. Scoring / tagging / clustering runner status from FastAPI.",
         inputSchema: { type: "object", properties: {} },
     },
 ];

--- a/mcp-server/src/tools/cdp.ts
+++ b/mcp-server/src/tools/cdp.ts
@@ -1,3 +1,4 @@
+import { getCdpBaseUrl } from "../utils/capabilities.js";
 import { sendCdpCommand, findPageTarget } from "../utils/cdp.js";
 
 interface ToolDef {
@@ -16,7 +17,7 @@ export const cdpToolDefs: ToolDef[] = [
     {
         name: "cdp_screenshot",
         description:
-            "Take a screenshot of the Electron app window via Chrome DevTools Protocol. Returns a base64-encoded PNG image. Requires the Electron app to be running in dev mode (port 9222).",
+            "Requires electron_cdp (gallery_status). Screenshot via CDP; PNG image. Dev Electron with remote debugging (default 9222; override ELECTRON_CDP_URL / ELECTRON_REMOTE_DEBUGGING_PORT).",
         inputSchema: {
             type: "object",
             properties: {
@@ -30,7 +31,7 @@ export const cdpToolDefs: ToolDef[] = [
     {
         name: "cdp_evaluate",
         description:
-            "Execute JavaScript in the Electron renderer page context and return the result. Useful for inspecting app state, DOM, or Zustand stores.",
+            "Requires electron_cdp. Run JS in the renderer page context; inspect DOM/state.",
         inputSchema: {
             type: "object",
             properties: {
@@ -45,7 +46,7 @@ export const cdpToolDefs: ToolDef[] = [
     {
         name: "cdp_console_logs",
         description:
-            "Capture console messages from the Electron renderer for a brief period. Returns any console.log/warn/error output.",
+            "Requires electron_cdp. Collect renderer console output for duration_ms (default 2000, max 10000).",
         inputSchema: {
             type: "object",
             properties: {
@@ -148,10 +149,11 @@ export async function handleCdpTool(name: string, args: Record<string, unknown>)
     } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : String(error);
         if (msg.includes("fetch failed") || msg.includes("ECONNREFUSED") || msg.includes("WebSocket")) {
+            const cdp = getCdpBaseUrl();
             return {
                 content: [{
                     type: "text",
-                    text: `Electron app CDP is not reachable at port 9222. Is the app running in dev mode?\nError: ${msg}`,
+                    text: `Electron CDP is not reachable at ${cdp}. Run the gallery in dev with remote debugging (or set ELECTRON_CDP_URL / ELECTRON_REMOTE_DEBUGGING_PORT).\nError: ${msg}`,
                 }],
                 isError: true,
             };

--- a/mcp-server/src/utils/capabilities.ts
+++ b/mcp-server/src/utils/capabilities.ts
@@ -1,0 +1,76 @@
+import { resolveApiUrl } from "./config.js";
+
+/**
+ * Base URL for Chrome DevTools HTTP (Electron remote debugging).
+ * ELECTRON_CDP_URL wins if set (e.g. http://127.0.0.1:9222).
+ * Else ELECTRON_REMOTE_DEBUGGING_PORT or ELECTRON_CDP_PORT (digits only), default 9222.
+ */
+export function getCdpBaseUrl(): string {
+    const full = process.env.ELECTRON_CDP_URL?.trim();
+    if (full) {
+        return full.replace(/\/$/, "");
+    }
+    const port =
+        process.env.ELECTRON_REMOTE_DEBUGGING_PORT?.trim() ||
+        process.env.ELECTRON_CDP_PORT?.trim() ||
+        "9222";
+    if (!/^\d+$/.test(port)) {
+        return "http://127.0.0.1:9222";
+    }
+    return `http://127.0.0.1:${port}`;
+}
+
+export async function probePythonApi(): Promise<{
+    reachable: boolean;
+    base_url: string;
+    error?: string;
+}> {
+    const base_url = await resolveApiUrl();
+    try {
+        const resp = await fetch(`${base_url}/api/health`, { signal: AbortSignal.timeout(3000) });
+        if (resp.ok) {
+            return { reachable: true, base_url };
+        }
+        return { reachable: false, base_url, error: `HTTP ${resp.status} ${resp.statusText}` };
+    } catch (e) {
+        const error = e instanceof Error ? e.message : String(e);
+        return { reachable: false, base_url, error };
+    }
+}
+
+export async function probeElectronCdp(): Promise<{
+    reachable: boolean;
+    cdp_url: string;
+    target_count?: number;
+    error?: string;
+}> {
+    const cdp_url = getCdpBaseUrl();
+    try {
+        const resp = await fetch(`${cdp_url}/json`, { signal: AbortSignal.timeout(3000) });
+        if (!resp.ok) {
+            return { reachable: false, cdp_url, error: `HTTP ${resp.status} ${resp.statusText}` };
+        }
+        const targets = (await resp.json()) as unknown;
+        const target_count = Array.isArray(targets) ? targets.length : 0;
+        return { reachable: true, cdp_url, target_count };
+    } catch (e) {
+        const error = e instanceof Error ? e.message : String(e);
+        return { reachable: false, cdp_url, error };
+    }
+}
+
+export async function collectGalleryStatus(): Promise<Record<string, unknown>> {
+    const [python_api, electron_cdp] = await Promise.all([probePythonApi(), probeElectronCdp()]);
+    return {
+        python_api,
+        electron_cdp,
+        hints: {
+            api_tools: python_api.reachable
+                ? "api_* tools should work against the resolved base_url."
+                : "Start the Python WebUI (e.g. run_webui.bat) for api_* tools.",
+            cdp_tools: electron_cdp.reachable
+                ? "cdp_* tools should work (Electron dev + remote debugging)."
+                : "Run the gallery in dev with remote debugging (default port 9222) for cdp_* tools.",
+        },
+    };
+}

--- a/mcp-server/src/utils/cdp.ts
+++ b/mcp-server/src/utils/cdp.ts
@@ -1,4 +1,4 @@
-const CDP_URL = "http://127.0.0.1:9222";
+import { getCdpBaseUrl } from "./capabilities.js";
 
 interface CdpTarget {
     id: string;
@@ -12,7 +12,7 @@ interface CdpTarget {
  * Discover available CDP targets from the Electron dev server.
  */
 export async function listTargets(): Promise<CdpTarget[]> {
-    const resp = await fetch(`${CDP_URL}/json`, { signal: AbortSignal.timeout(3000) });
+    const resp = await fetch(`${getCdpBaseUrl()}/json`, { signal: AbortSignal.timeout(3000) });
     return (await resp.json()) as CdpTarget[];
 }
 

--- a/src/components/Diagnostics/DiagnosticsModal.tsx
+++ b/src/components/Diagnostics/DiagnosticsModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import type { DiagnosticsReport, ProcessMemorySnapshot } from '../../electron.d';
 
 interface Props {
     isOpen: boolean;
@@ -6,8 +7,8 @@ interface Props {
 }
 
 export const DiagnosticsModal: React.FC<Props> = ({ isOpen, onClose }) => {
-    const [diagnostics, setDiagnostics] = useState<any>(null);
-    const [rendererMemory, setRendererMemory] = useState<any>(null);
+    const [diagnostics, setDiagnostics] = useState<DiagnosticsReport | null>(null);
+    const [rendererMemory, setRendererMemory] = useState<ProcessMemorySnapshot | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -29,9 +30,9 @@ export const DiagnosticsModal: React.FC<Props> = ({ isOpen, onClose }) => {
                 setDiagnostics(diagData);
                 setRendererMemory(rendMem);
             }
-        } catch (err: any) {
+        } catch (err: unknown) {
             console.error('Failed to load diagnostics:', err);
-            setError(err.message || 'Failed to load diagnostics.');
+            setError(err instanceof Error ? err.message : 'Failed to load diagnostics.');
         } finally {
             setIsLoading(false);
         }

--- a/src/components/Runs/RunsPage.tsx
+++ b/src/components/Runs/RunsPage.tsx
@@ -145,7 +145,7 @@ export function RunsPage({ folders, foldersLoading, onRefreshFolders }: RunsPage
         setCreateBusy(true);
         try {
             const operations = Object.entries(createOperations)
-                .filter(([_, enabled]) => enabled)
+                .filter(([, enabled]) => enabled)
                 .map(([key]) => key);
             
             if (operations.length === 0) {
@@ -248,7 +248,7 @@ export function RunsPage({ folders, foldersLoading, onRefreshFolders }: RunsPage
                                         </span>
                                     </div>
                                     <div style={{ fontSize: '0.75em', color: '#666', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        {((job as any).input_path ?? '').split(/[/\\]/).pop() || (job as any).input_path || 'No target'}
+                                        {(job.input_path ?? '').split(/[/\\]/).pop() || job.input_path || 'No target'}
                                     </div>
                                     <div style={{ fontSize: '0.7em', color: '#555', marginTop: 4 }}>
                                         {new Date(job.created_at || '').toLocaleString()}

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -12,6 +12,20 @@ export interface BackendJobInfo {
     [key: string]: unknown;
 }
 
+export interface DiagnosticsReport {
+    os: { platform: string; release: string; arch: string; uptime: number };
+    versions: { electron: string; node: string; chrome: string; v8: string };
+    database: { engine: string; connected: boolean; host: string; database: string };
+    api: { url: string; connected: boolean };
+    memory: { workingSetSize: number; peakWorkingSetSize: number; privateBytes?: number; sharedBytes?: number } | null;
+}
+
+export interface ProcessMemorySnapshot {
+    workingSetSize: number;
+    peakWorkingSetSize: number;
+    privateBytes?: number;
+    sharedBytes?: number;
+}
 
 interface ImageQueryOptions {
     limit?: number;
@@ -259,14 +273,8 @@ declare global {
             getGalleryMode: () => Promise<'db' | 'folder'>;
             onAppModeChanged: (callback: (mode: 'db' | 'folder') => void) => () => void;
             selectDirectory: () => Promise<string | null>;
-            getDiagnostics: () => Promise<{
-                os: { platform: string; release: string; arch: string; uptime: number };
-                versions: { electron: string; node: string; chrome: string; v8: string };
-                database: { engine: string; connected: boolean; host: string; database: string };
-                api: { url: string; connected: boolean };
-                memory: { workingSetSize: number; peakWorkingSetSize: number; privateBytes?: number; sharedBytes?: number } | null;
-            }>;
-            getProcessMemoryInfo: () => Promise<{ workingSetSize: number; peakWorkingSetSize: number; privateBytes?: number; sharedBytes?: number } | null>;
+            getDiagnostics: () => Promise<DiagnosticsReport>;
+            getProcessMemoryInfo: () => Promise<ProcessMemorySnapshot | null>;
             onOpenSettings: (callback: () => void) => () => void;
             onOpenDuplicates: (callback: () => void) => () => void;
             onOpenRuns: (callback: () => void) => () => void;

--- a/src/hooks/useFolders.ts
+++ b/src/hooks/useFolders.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { buildFolderTree } from '../components/Tree/treeUtils';
 import type { Folder } from '../components/Tree/treeUtils';
 import { bridge } from '../bridge';
@@ -19,13 +19,13 @@ export function useFolders(): { folders: Folder[]; loading: boolean; refresh: ()
     const [loading, setLoading] = useState(true);
     const initialLoadDone = useRef(false);
 
-    const fetchFolders = () => {
+    const fetchFolders = useCallback(() => {
         if (!initialLoadDone.current) {
             setLoading(true);
         }
 
         const foldersPromise = bridge.getFolders();
-        
+
         foldersPromise.then(folderRows => {
             setFlatFolders(folderRows);
             initialLoadDone.current = true;
@@ -34,12 +34,13 @@ export function useFolders(): { folders: Folder[]; loading: boolean; refresh: ()
             console.error('[useFolders] Failed to fetch folders:', err);
             setLoading(false);
         });
-    };
+    }, []);
 
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        fetchFolders();
-    }, []);
+        void queueMicrotask(() => {
+            fetchFolders();
+        });
+    }, [fetchFolders]);
 
     const folderTree = useMemo(() => buildFolderTree(flatFolders), [flatFolders]);
 

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -47,7 +47,7 @@ export class ApiClient {
         }
 
         const getPort = (): Promise<number> => {
-            const electron = (window as any).electron;
+            const electron = window.electron;
             if (electron?.getApiPort) {
                 return electron.getApiPort();
             }


### PR DESCRIPTION
## Summary
- expand the gallery MCP server with `gallery_status`, FastAPI probe tools, CDP capability detection, and configurable CDP endpoint resolution
- refresh agent and workspace docs for the consolidated `imgscore-el-gallery` setup, optional backend MCP usage, and kanban workflow guidance
- sync roadmap/TODO/report documents to reflect completed MCP scope, EIS-104 quality-debt work, and backend config documentation
- add a user-facing guide for `config.api.url` / `config.api.port` behavior and related backend discovery rules
- tighten local typing and provider-related cleanup in diagnostics, runs, folder loading, and API client paths

## Testing
- `npm run test:run`