### PR TITLE
Improve backup capture-date grouping and config-driven defaults

### DIFF
--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1310,10 +1310,12 @@ export async function getAllScoredImagesForBackup(minScore: number): Promise<Sco
             i.file_name,
             i.score_general as composite_score,
             i.image_hash,
-            i.stack_id
+            i.stack_id,
+            (COALESCE(e.date_time_original, e.create_date, i.created_at))::date::text as capture_date
         FROM images i
         LEFT JOIN file_paths fp ON i.id = fp.image_id AND fp.path_type = 'WIN'
             AND POSITION('/thumbnails/' IN fp.path) = 0
+        LEFT JOIN image_exif e ON e.image_id = i.id
         WHERE i.score_general >= ?
         ORDER BY i.score_general DESC NULLS LAST
     `;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -42,6 +42,14 @@ function isUnresolvedSyncLayout(camera: string, lens: string): boolean {
     return camera === UNKNOWN_CAMERA_FOLDER || lens === UNKNOWN_LENS_FOLDER;
 }
 
+function backupDateKey(img: ScoredImageForBackup): string {
+    if (img.capture_date && /^\d{4}-\d{2}-\d{2}$/.test(img.capture_date)) {
+        return img.capture_date;
+    }
+    const dateMatch = img.path.match(/(\d{4}-\d{2}-\d{2})/);
+    return dateMatch ? dateMatch[1] : 'unknown';
+}
+
 const exiftool = new ExifTool({ maxProcs: 6 });
 
 function convertFsImagePathForExif(filePath: string): string {
@@ -1136,10 +1144,10 @@ async function startFullApplication(): Promise<void> {
                 return { copied: 0, skipped: 0, deduplicated: 0, errors: [] };
             }
 
-            // Group by date (YYYY-MM-DD) for locality in similarity checks
+            // Group by resolved capture date for locality in similarity checks.
             const groups = new Map<string, typeof allScored>();
             for (const img of allScored) {
-                const date = img.path.match(/(\d{4}-\d{2}-\d{2})/) ? img.path.match(/(\d{4}-\d{2}-\d{2})/)![1] : 'unknown';
+                const date = backupDateKey(img);
                 if (!groups.has(date)) groups.set(date, []);
                 groups.get(date)!.push(img);
             }
@@ -1220,16 +1228,8 @@ async function startFullApplication(): Promise<void> {
                 const details = await db.getImageDetails(img.id);
                 const camera = normalizeCameraModel(details?.exif_model);
                 const lens = normalizeLensFolderName(details?.exif_lens_model);
-                if (isUnresolvedSyncLayout(camera, lens)) {
-                    console.warn(
-                        `[Backup] Skip (missing camera/lens for layout): ${img.path} exif_model=${details?.exif_model ?? '—'} exif_lens_model=${details?.exif_lens_model ?? '—'}`
-                    );
-                    skipped++;
-                    continue;
-                }
-                const dateMatch = img.path.match(/(\d{4}-\d{2}-\d{2})/);
-                const dateStr = dateMatch ? dateMatch[1] : 'unknown';
-                const year = dateStr.split('-')[0];
+                const dateStr = backupDateKey(img);
+                const year = dateStr !== 'unknown' ? dateStr.split('-')[0] : 'unknown';
 
                 const relDir = path.join(camera, lens, year, dateStr);
                 const relPath = path.join(relDir, fileName);

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -179,7 +179,9 @@ export interface AppConfig {
     backup?: {
         /** Minimum quality score to include in backup */
         minScore?: number;
-        /** Maximum number of similar images (per stack or cluster) to include */
+        /** Similarity threshold used for embedding-based deduplication */
+        similarityThreshold?: number;
+        /** @deprecated Not used by backup pipeline (kept for backward compatibility). */
         maxInstances?: number;
     };
     [key: string]: unknown;
@@ -259,6 +261,7 @@ export interface ScoredImageForBackup {
     composite_score: number;
     image_hash: string | null;
     stack_id: number | null;
+    capture_date: string | null;
 }
 
 export interface BackupProgress {

--- a/src/components/Backup/BackupModal.tsx
+++ b/src/components/Backup/BackupModal.tsx
@@ -29,6 +29,25 @@ export const BackupModal: React.FC<Props> = ({ isOpen, targetPath, onClose, onCo
     const [similarityThreshold, setSimilarityThreshold] = useState(0.95);
     const runRef = useRef(false);
 
+    // Load configurable defaults when available.
+    useEffect(() => {
+        if (!isOpen || isRunning) return;
+        bridge.getConfig()
+            .then((config) => {
+                const cfgMin = Number(config?.backup?.minScore);
+                if (Number.isFinite(cfgMin)) {
+                    setMinScore(Math.max(0, Math.min(100, Math.round(cfgMin / 5) * 5)));
+                }
+                const cfgSimilarity = Number(config?.backup?.similarityThreshold);
+                if (Number.isFinite(cfgSimilarity)) {
+                    setSimilarityThreshold(Math.max(0.8, Math.min(0.99, cfgSimilarity)));
+                }
+            })
+            .catch((err) => {
+                console.warn('Failed to load backup defaults from config:', err);
+            });
+    }, [isOpen, isRunning]);
+
     // Check target info when modal opens or path changes
     useEffect(() => {
         if (isOpen && targetPath && !isRunning) {

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -194,6 +194,7 @@ interface AppConfig {
     };
     backup?: {
         minScore?: number;
+        similarityThreshold?: number;
         maxInstances?: number;
     };
     [key: string]: unknown;


### PR DESCRIPTION
### Motivation

- Backup grouping and destination folders relied on a YYYY-MM-DD regex in file paths which produced large "unknown" groups and fragile layouts for images lacking ISO date segments. 
- The Backup UI used hardcoded defaults (70 / 0.95) instead of honoring project configuration values. 
- The backup pipeline skipped images with unresolved camera/lens layout at copy time, causing qualifying images to be omitted from exports.

### Description

- Expose a normalized `capture_date` in the backup candidate query by joining `image_exif` and using `COALESCE(image_exif.date_time_original, image_exif.create_date, images.created_at)` so DB-derived dates are available to backup logic. 
- Add `backupDateKey` helper and switch grouping/folder naming to prefer `capture_date` with the original path-regex as a fallback (`unknown`). 
- Stop skipping images in the backup copy phase when camera or lens metadata is unresolved so files now export into the fallback camera/lens folders instead of being silently skipped. 
- Make `BackupModal` load defaults from `config.backup.minScore` and `config.backup.similarityThreshold` (with safe clamping/rounding) while preserving current UI fallbacks; update shared types (`ScoredImageForBackup.capture_date` and `backup.similarityThreshold`) for renderer/electron surfaces. 

### Testing

- Ran unit tests with `npm run -s test:run`, all tests passed: `133 passed (133)`. 
- Type-checked renderer code with `npx tsc --noEmit`, which completed successfully. 
- Type-checked Electron main sources with `npx tsc -p electron/tsconfig.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9967f2b008323980bf5a0034d91ad)