### PR TITLE
Add conservative Vitest coverage thresholds and CI-friendly reporters

### DIFF
--- a/docs/guides/03-testing-and-coverage.md
+++ b/docs/guides/03-testing-and-coverage.md
@@ -1,0 +1,55 @@
+# Testing and Coverage Guide
+
+This project uses Vitest for unit/integration tests and V8 coverage reporting.
+
+## Run tests
+
+- Run the full suite once (non-watch):
+
+```bash
+npm run test:run
+```
+
+- Run tests with coverage output for CI and local baselines:
+
+```bash
+npm run test:coverage
+```
+
+## Coverage outputs (CI-friendly)
+
+`npm run test:coverage` now emits multiple reporter formats under `coverage/`:
+
+- `text` + `text-summary`: readable output in CI logs
+- `json-summary`: machine-readable totals for tooling/baseline capture
+- `lcov`: artifact-friendly format for CI systems and coverage dashboards
+- `html`: interactive local inspection report
+
+## Threshold policy (conservative baseline, ratchet upward)
+
+Current coverage thresholds are intentionally conservative so they reflect the current suite health while still preventing regressions.
+
+- Branches: `6%`
+- Functions: `8%`
+- Lines: `10%`
+- Statements: `10%`
+
+### How to interpret failures
+
+A threshold failure means the measured total dropped below one or more configured minimums. This is usually a signal that:
+
+1. New code was added without tests, or
+2. Existing tests were removed/changed and no longer execute previously covered paths.
+
+### When and how to raise thresholds
+
+After capturing a stable baseline (for example from main branch CI):
+
+1. Record totals from `coverage/coverage-summary.json`.
+2. Increase one or more thresholds in `vitest.config.ts` by a small increment (typically `+1%` to `+3%`).
+3. Run `npm run test:coverage` and ensure CI passes.
+4. Repeat periodically as meaningful test coverage improves.
+
+Avoid lowering thresholds except for explicit, reviewed reasons (for example large refactors with temporary coverage disruption).
+
+[← Back to Guides](README.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,5 +3,6 @@
 Development workflows and maintenance recommendations.
 
 - [01 - Lint Recommendations](01-lint-recommendations.md) - Code quality and ESLint fix guidance (see also [Reports: ESLint Audit](../reports/03-eslint-audit-2026-03.md) for full audit)
+- [03 - Testing and Coverage Guide](03-testing-and-coverage.md) - Test commands, coverage artifacts, and threshold ratcheting policy
 
 [← Back to Documentation Index](../README.md)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,9 +10,17 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'electron/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'text-summary', 'json-summary', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      reportOnFailure: true,
       include: ['src/**/*.ts', 'src/**/*.tsx', 'electron/**/*.ts'],
       exclude: ['**/*.d.ts', '**/*.test.*', '**/*.spec.*'],
+      thresholds: {
+        branches: 6,
+        functions: 8,
+        lines: 10,
+        statements: 10,
+      },
     },
   },
 });


### PR DESCRIPTION
### Motivation

- Provide CI-friendly coverage artifacts and machine-readable summaries so coverage can be inspected by pipelines and stored as artifacts.  
- Establish an explicit conservative baseline for coverage thresholds to prevent regressions and enable incremental ratcheting as test coverage improves.

### Description

- Update `vitest.config.ts` coverage settings to add reporters `text-summary`, `json-summary`, `lcov`, and `html`, set `reportsDirectory: './coverage'`, and enable `reportOnFailure: true`.  
- Add conservative coverage `thresholds` to `vitest.config.ts` (`branches: 6`, `functions: 8`, `lines: 10`, `statements: 10`).  
- Add `docs/guides/03-testing-and-coverage.md` describing `npm run test:run`, `npm run test:coverage`, the CI-friendly reporter outputs, and a policy for interpreting/updating thresholds.  
- Link the new guide from `docs/guides/README.md`.

### Testing

- Ran `npm run test:run`, which failed due to pre-existing unit test expectation mismatches in `electron/mediaUrlParse.test.ts` (unrelated to the config/docs changes).  
- Ran `npm run test:coverage`, which also reported the same failing tests but produced coverage outputs and summaries as configured.  
- Captured baseline coverage totals from the run: statements `19.38%`, branches `15.97%`, functions `17.76%`, lines `19.59%`, which are above the configured conservative thresholds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dada5f65bc8323b1adb271d15edae0)