### PR TITLE
Normalize contract/typegen scripts to image-scoring-backend sibling path

### DIFF
--- a/docs/guides/02-api-backend-config.md
+++ b/docs/guides/02-api-backend-config.md
@@ -7,7 +7,7 @@ This gallery can discover the Python backend automatically, but you can also pin
 The backend base URL is resolved in this order:
 
 1. **`config.api.url`**: exact base URL, highest priority
-2. **Sibling backend lock file**: `webui.lock` / `webui-debug.lock` from `image-scoring-backend` or legacy `image-scoring`
+2. **Sibling backend lock file**: `webui.lock` / `webui-debug.lock` from `image-scoring-backend`
 3. **Fallback host/port**: `config.api.host` + `config.api.port`
 4. **Default fallback**: `http://127.0.0.1:7860`
 
@@ -52,7 +52,3 @@ Automatic lock-file discovery checks these sibling locations relative to the gal
 
 - `../image-scoring-backend/webui.lock`
 - `../image-scoring-backend/webui-debug.lock`
-- `../image-scoring/webui.lock`
-- `../image-scoring/webui-debug.lock`
-
-This supports the current `image-scoring-backend` repo name and the older `image-scoring` layout.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:run": "cross-env VITEST=1 vitest run",
     "test:coverage": "cross-env VITEST=1 vitest run --coverage",
     "test:db": "cd ../image-scoring && python scripts/setup_test_db.py",
-    "generate:api-types": "npx openapi-typescript ../image-scoring/openapi.json -o electron/api.generated.ts",
+    "generate:api-types": "node scripts/generate-api-types.mjs",
     "contract:update": "node scripts/sync-api-contract.mjs --update",
     "contract:check": "node scripts/sync-api-contract.mjs --check",
     "contract:diff": "node scripts/sync-api-contract.mjs --diff",

--- a/scripts/generate-api-types.mjs
+++ b/scripts/generate-api-types.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import { existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SIBLING_OPENAPI_PATH = resolve(__dirname, '..', '..', 'image-scoring-backend', 'openapi.json');
+const OUTPUT_PATH = resolve(__dirname, '..', 'electron', 'api.generated.ts');
+
+function ensureSiblingOpenApiExists() {
+    if (existsSync(SIBLING_OPENAPI_PATH)) return;
+
+    console.error('[generate:api-types] Missing sibling backend OpenAPI file.');
+    console.error(`Expected: ${SIBLING_OPENAPI_PATH}`);
+    console.error('Action: clone/open the backend repo as ../image-scoring-backend and generate openapi.json, then re-run `npm run generate:api-types`.');
+    process.exit(1);
+}
+
+ensureSiblingOpenApiExists();
+
+const result = spawnSync('npx', ['openapi-typescript', SIBLING_OPENAPI_PATH, '-o', OUTPUT_PATH], {
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+});
+
+if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+}
+
+console.log(`[generate:api-types] Wrote API types to ${OUTPUT_PATH}`);

--- a/scripts/sync-api-contract.mjs
+++ b/scripts/sync-api-contract.mjs
@@ -3,9 +3,9 @@
  * API contract snapshot sync script.
  *
  * Usage:
- *   node scripts/sync-api-contract.mjs --update   # Fetch and save openapi.json
- *   node scripts/sync-api-contract.mjs --check    # Compare local snapshot with live backend
- *   node scripts/sync-api-contract.mjs --diff     # Copy from sibling repo (no backend needed)
+ *   node scripts/sync-api-contract.mjs --update   # Fetch and save openapi.json (fallback to ../image-scoring-backend/openapi.json)
+ *   node scripts/sync-api-contract.mjs --check    # Compare local snapshot with live backend (fallback to sibling backend file)
+ *   node scripts/sync-api-contract.mjs --diff     # Copy from ../image-scoring-backend/openapi.json (no backend needed)
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'fs';
@@ -40,18 +40,23 @@ function normalizeForComparison(obj) {
     return JSON.stringify(obj, null, 2);
 }
 
+function ensureSiblingOpenApiExists(contextMessage) {
+    if (existsSync(SIBLING_PATH)) return;
+    console.error(`[contract:${mode?.replace('--', '') ?? 'unknown'}] Missing sibling backend OpenAPI file.`);
+    console.error(`Expected: ${SIBLING_PATH}`);
+    console.error(`Action: clone/open the backend repo as ../image-scoring-backend and generate openapi.json, then retry ${contextMessage}.`);
+    process.exit(1);
+}
+
 async function main() {
     if (mode === '--diff') {
-        // Copy from sibling repo without needing the backend running
-        if (!existsSync(SIBLING_PATH)) {
-            console.error(`Sibling repo openapi.json not found at: ${SIBLING_PATH}`);
-            process.exit(1);
-        }
+        // Copy from sibling backend repo without needing the backend running
+        ensureSiblingOpenApiExists('`npm run contract:diff`');
         const source = readFileSync(SIBLING_PATH, 'utf-8');
         const current = existsSync(SNAPSHOT_PATH) ? readFileSync(SNAPSHOT_PATH, 'utf-8') : null;
 
         if (current && normalizeForComparison(JSON.parse(source)) === normalizeForComparison(JSON.parse(current))) {
-            console.log('Snapshot is up to date with sibling repo.');
+            console.log('Snapshot is up to date with sibling backend repo.');
             return;
         }
 
@@ -65,16 +70,15 @@ async function main() {
         try {
             schema = await fetchOpenApi();
         } catch {
-            // Fallback to sibling repo file
+            // Fallback to sibling backend repo file
             if (existsSync(SIBLING_PATH)) {
-                console.log('Backend not reachable, copying from sibling repo...');
+                console.log('Backend not reachable, copying from sibling backend repo...');
                 const source = readFileSync(SIBLING_PATH, 'utf-8');
                 writeFileSync(SNAPSHOT_PATH, source);
                 console.log(`Updated snapshot from ${SIBLING_PATH}`);
                 return;
             }
-            console.error('Backend not reachable and sibling repo openapi.json not found.');
-            process.exit(1);
+            ensureSiblingOpenApiExists('`npm run contract:update`');
         }
         const formatted = JSON.stringify(schema, null, 2) + '\n';
         writeFileSync(SNAPSHOT_PATH, formatted);
@@ -93,13 +97,12 @@ async function main() {
         try {
             live = await fetchOpenApi();
         } catch {
-            // Fallback: compare with sibling repo file
+            // Fallback: compare with sibling backend repo file
             if (existsSync(SIBLING_PATH)) {
                 live = JSON.parse(readFileSync(SIBLING_PATH, 'utf-8'));
-                console.log('(Comparing against sibling repo file — backend not reachable)');
+                console.log('(Comparing against sibling backend repo file — backend not reachable)');
             } else {
-                console.error('Cannot check: backend not reachable and sibling openapi.json not found.');
-                process.exit(1);
+                ensureSiblingOpenApiExists('`npm run contract:check`');
             }
         }
 


### PR DESCRIPTION
### Motivation
- Standardize where API contract and type generation look for the backend OpenAPI snapshot so tooling and docs consistently use the `image-scoring-backend` sibling checkout.
- Provide clearer, actionable errors when the expected sibling backend artifact is missing to reduce confusion during local development and CI.

### Description
- Replaced the inline `openapi-typescript` invocation in `package.json` with a dedicated script `scripts/generate-api-types.mjs` that enforces the sibling path `../image-scoring-backend/openapi.json` before running type generation via `npx openapi-typescript`.
- Added `ensureSiblingOpenApiExists` validation to `scripts/sync-api-contract.mjs`, updated its usage/help text, and switched fallback/messaging to consistently reference the `../image-scoring-backend/openapi.json` convention.
- Updated documentation in `docs/guides/02-api-backend-config.md` to remove legacy `image-scoring` sibling references and mirror the normalized `image-scoring-backend` layout.
- New script file `scripts/generate-api-types.mjs` was added and `scripts/sync-api-contract.mjs` was modified to fail fast with clear actionable guidance when the sibling file is absent.

### Testing
- Ran `npm run generate:api-types` which now fails early when `../image-scoring-backend/openapi.json` is missing and prints an actionable message directing the developer to add the sibling repo and regenerate the OpenAPI snapshot (expected, exit code non-zero).
- Ran `npm run contract:diff` which now emits the same actionable missing-sibling-backend message when the sibling OpenAPI file is absent (expected, exit code non-zero).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dada62157883238a7c2b30b43236a3)