### PR TITLE
Align example config templates with postgres-first schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This application provides a high-performance interface for browsing and filterin
 - **Database**: Production uses PostgreSQL and/or backend API SQL mode (see `docs/architecture/02-database-design.md`).
 - **Project layout**: For automatic API port discovery, keep **image-scoring-backend** and **image-scoring-gallery** as sibling directories. Override via `config.json` (`api.url` or `api.port`) if your layout differs.
 - **Environment overrides:** Copy `environment.example.json` to `environment.json` (gitignored) for machine-specific paths, ports, and URLs; `environment.json` overrides overlapping keys in `config.json`.
+- **Migration note:** Legacy Firebird keys (for example `database.host`, `database.path`, and `firebird.path`) are historical compatibility artifacts and are no longer first-class config fields; use `database.engine` (`postgres` or `api`) plus `database.postgres.*` / `database.api.*` instead.
 
 ## Getting Started
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,13 +1,8 @@
 {
     "_example_comment_dev_url": "Keep dev.url in sync with vite.config.ts server.port (default 5173; strictPort fails if that port is busy—free it or change both places).",
     "database": {
-        "engine": "firebird",
-        "provider": "firebird",
-        "host": "127.0.0.1",
-        "port": 3050,
-        "user": "sysdba",
-        "password": "masterkey",
-        "path": "../image-scoring-backend/SCORING_HISTORY.FDB",
+        "engine": "postgres",
+        "provider": "postgres",
         "postgres": {
             "host": "127.0.0.1",
             "port": 5432,
@@ -31,9 +26,6 @@
     },
     "api": {
         "url": "http://127.0.0.1:7860"
-    },
-    "firebird": {
-        "path": "../image-scoring-backend/Firebird"
     },
     "paths": {
         "remap_legacy_image_scoring_thumbnails": true,

--- a/docs/guides/02-api-backend-config.md
+++ b/docs/guides/02-api-backend-config.md
@@ -2,6 +2,10 @@
 
 This gallery can discover the Python backend automatically, but you can also pin or redirect it with `config.json`.
 
+## Migration Note
+
+Legacy Firebird-era keys (for example `database.host`, `database.path`, and top-level `firebird.path`) are kept only for historical context and are no longer first-class configuration fields. Prefer `database.engine` with `database.postgres.*` (or `database.api.*` when using API SQL mode), plus top-level `api.*` overrides documented below.
+
 ## Resolution Order
 
 The backend base URL is resolved in this order:

--- a/electron/config.examples.test.ts
+++ b/electron/config.examples.test.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { normalizeAppConfig } from './config';
+
+describe('config examples', () => {
+  function loadExample(filename: string) {
+    const filePath = path.resolve(__dirname, '..', filename);
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    return normalizeAppConfig(raw);
+  }
+
+  it('normalizes config.example.json to postgres defaults with nested postgres config', () => {
+    const normalized = loadExample('config.example.json');
+
+    expect(normalized.database.engine).toBe('postgres');
+    expect(normalized.database.provider).toBe('postgres');
+    expect(normalized.database.postgres).toMatchObject({
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'image_scoring',
+      user: 'postgres',
+      password: 'postgres',
+    });
+  });
+
+  it('normalizes environment.example.json with postgres shape and defaults', () => {
+    const normalized = loadExample('environment.example.json');
+
+    expect(normalized.database.engine).toBe('postgres');
+    expect(normalized.database.provider).toBe('postgres');
+    expect(normalized.database.postgres).toMatchObject({
+      host: '127.0.0.1',
+      port: 5432,
+      database: 'image_scoring',
+      user: 'postgres',
+      password: 'postgres',
+    });
+    expect(normalized.database).not.toHaveProperty('api');
+  });
+});

--- a/environment.example.json
+++ b/environment.example.json
@@ -1,27 +1,22 @@
 {
-    "_comment": "Copy to environment.json and set real paths, ports, and URLs for this machine. environment.json is gitignored. Values override the same keys in config.json when both exist.",
+    "_comment": "Copy to environment.json and set machine-specific values. environment.json is gitignored and overrides matching keys from config.json.",
     "database": {
-        "host": "127.0.0.1",
-        "port": 3050,
-        "user": "sysdba",
-        "password": "masterkey",
-        "path": "../image-scoring-backend/SCORING_HISTORY.FDB",
         "postgres": {
             "host": "127.0.0.1",
             "port": 5432,
             "database": "image_scoring",
             "user": "postgres",
             "password": "postgres"
+        },
+        "api": {
+            "url": "http://127.0.0.1:7860",
+            "timeout": 10000
         }
     },
-    "dev": {
-        "url": "http://localhost:5173"
-    },
     "api": {
-        "url": "http://127.0.0.1:7860"
-    },
-    "firebird": {
-        "path": "../image-scoring-backend/Firebird"
+        "url": "http://127.0.0.1:7860",
+        "host": "127.0.0.1",
+        "port": 7860
     },
     "paths": {
         "thumbnail_base_dir": "../image-scoring-backend/thumbnails",
@@ -31,8 +26,5 @@
                 "to": "../image-scoring-backend/thumbnails"
             }
         ]
-    },
-    "browser_server": {
-        "port": 3001
     }
 }


### PR DESCRIPTION
### Motivation

- Make PostgreSQL the default configuration path and remove legacy Firebird-first artifacts to match the runtime normalization in `normalizeAppConfig`.
- Keep example environment overrides small and limited to keys actually consumed at runtime to reduce confusion and drift.
- Add a lightweight guard to ensure example files continue to produce a valid normalized config shape.

### Description

- Update `config.example.json` to set `database.engine` / `database.provider` to `postgres` and remove Firebird-only top-level fields (`database.host`, `database.path`, and `firebird.path`).
- Simplify `environment.example.json` to only include keys used by `normalizeAppConfig` (nested `database.postgres.*`, optional `database.api.*`, top-level `api.*`, and `paths.*`).
- Add `electron/config.examples.test.ts` which loads `config.example.json` and `environment.example.json`, runs `normalizeAppConfig` on each, and asserts the normalized PostgreSQL-shaped output.
- Add a short migration note to `README.md` and `docs/guides/02-api-backend-config.md` clarifying that legacy Firebird keys are historical and that `database.engine` with `database.postgres.*` / `database.api.*` should be used going forward.

### Testing

- Ran the new spec with `npm run test:run -- electron/config.examples.test.ts`, which completed successfully with `1 file, 2 tests passed`.
- No other automated tests were modified; this change is focused on docs/examples and a small validation test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e44838764c8323b4fa6154076c0c0e)