### PR TITLE
Make electron/types.ts canonical; sync renderer declarations and add CI type-sync check

### DIFF
--- a/.github/workflows/test-and-contract.yml
+++ b/.github/workflows/test-and-contract.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:run
 
+      - name: Check renderer/electron type sync
+        run: npm run check:type-sync
+
 
       - name: Fetch backend OpenAPI snapshot source
         run: git clone --depth 1 https://github.com/synthet/image-scoring-backend ../image-scoring-backend

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "contract:validate": "node scripts/validate-api-types.mjs",
     "dev:browser": "npm run dev:web",
     "server": "npx tsx server/index.ts",
-    "start:browser": "npm run build && node dist-server/index.js"
+    "start:browser": "npm run build && node dist-server/index.js",
+    "check:type-sync": "node scripts/check-type-sync.mjs"
   },
   "build": {
     "forceCodeSigning": false,

--- a/scripts/check-type-sync.mjs
+++ b/scripts/check-type-sync.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const ELECTRON_TYPES = resolve(ROOT, 'electron/types.ts');
+const RENDERER_DECL = resolve(ROOT, 'src/electron.d.ts');
+
+function read(filePath) {
+  return readFileSync(filePath, 'utf8');
+}
+
+function parseExportedTypeNames(source) {
+  const names = new Set();
+  const regex = /^export\s+(?:interface|type)\s+([A-Za-z0-9_]+)/gm;
+  let match;
+  while ((match = regex.exec(source)) !== null) {
+    names.add(match[1]);
+  }
+  return names;
+}
+
+function parseNamedTypeClause(source, keyword) {
+  const regex = new RegExp(`${keyword}\\s+type\\s+\\{([\\s\\S]*?)\\}\\s+from\\s+['\"]\\.\\.\\/electron\\/types['\"]`, 'm');
+  const match = source.match(regex);
+  if (!match) {
+    return null;
+  }
+
+  const names = new Set();
+  for (const rawLine of match[1].split('\n')) {
+    const trimmed = rawLine.replace(/\/\/.*$/, '').trim();
+    if (!trimmed) continue;
+    const normalized = trimmed.replace(/,$/, '');
+    const local = normalized.split(/\s+as\s+/)[0].trim();
+    if (local) {
+      names.add(local);
+    }
+  }
+  return names;
+}
+
+function diff(setA, setB) {
+  return [...setA].filter((name) => !setB.has(name)).sort();
+}
+
+const electronTypesSource = read(ELECTRON_TYPES);
+const rendererDeclSource = read(RENDERER_DECL);
+
+const canonical = parseExportedTypeNames(electronTypesSource);
+const imported = parseNamedTypeClause(rendererDeclSource, 'import');
+const reexported = parseNamedTypeClause(rendererDeclSource, 'export');
+
+const errors = [];
+
+if (!imported) {
+  errors.push("Missing `import type { ... } from '../electron/types'` in src/electron.d.ts.");
+}
+
+if (!reexported) {
+  errors.push("Missing `export type { ... } from '../electron/types'` in src/electron.d.ts.");
+}
+
+if (imported && reexported) {
+  const importOnly = diff(imported, reexported);
+  const exportOnly = diff(reexported, imported);
+  if (importOnly.length || exportOnly.length) {
+    errors.push(`Import/export type lists are out of sync. import-only: [${importOnly.join(', ')}], export-only: [${exportOnly.join(', ')}].`);
+  }
+
+  const missingFromCanonical = diff(imported, canonical);
+  if (missingFromCanonical.length) {
+    errors.push(`src/electron.d.ts references unknown canonical types: [${missingFromCanonical.join(', ')}].`);
+  }
+}
+
+if (errors.length) {
+  console.error('Type sync check failed.');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('Type sync check passed: src/electron.d.ts imports/re-exports canonical types from electron/types.ts.');

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -27,266 +27,37 @@ export interface ProcessMemorySnapshot {
     sharedBytes?: number;
 }
 
-interface ImageQueryOptions {
-    limit?: number;
-    offset?: number;
-    folderId?: number;
-    folderIds?: number[];
-    minRating?: number;
-    colorLabel?: string;
-    keyword?: string;
-    sortBy?: string;
-    order?: 'ASC' | 'DESC';
-    smartCover?: boolean;
-    capturedDate?: string;
-}
+import type {
+    AppConfig,
+    BackupProgress,
+    BackupResult,
+    BackupTargetInfo,
+    DuplicateResponse,
+    ExportImageContext,
+    FileImageMetadataResult,
+    FolderRow,
+    FsReadDirResult,
+    ImageDetail,
+    ImageQueryOptions,
+    ImageRow,
+    ImageUpdates,
+} from '../electron/types';
 
-interface ImageRow {
-    id: number;
-    file_path: string;
-    file_name: string;
-    score_general: number;
-    score_technical: number;
-    score_aesthetic: number;
-    score_spaq: number;
-    score_ava: number;
-    score_liqe: number;
-    rating: number;
-    label: string | null;
-    created_at?: string;
-    thumbnail_path?: string;
-    capture_date?: string;
-    is_capture_date_fallback?: boolean;
-}
-
-interface ImageDetail extends ImageRow {
-    job_id?: string;
-    file_type?: string;
-    score?: number;
-    score_koniq?: number;
-    score_paq2piq?: number;
-    title?: string;
-    description?: string;
-    keywords?: string;
-    metadata?: string;
-    scores_json?: string;
-    model_version?: string;
-    image_hash?: string;
-    folder_id?: number;
-    stack_id?: number;
-    burst_uuid?: string;
-    win_path?: string;
-    file_exists?: boolean;
-    image_uuid?: string;
-}
-
-interface ImageUpdates {
-    title?: string;
-    description?: string;
-    rating?: number;
-    label?: string;
-    keywords?: string;
-}
-
-interface FolderRow {
-    id: number;
-    path: string;
-    parent_id: number | null;
-    is_fully_scored: number;
-    image_count: number;
-}
-
-interface DuplicatePair {
-    image_id_a: number;
-    image_id_b: number;
-    similarity: number;
-    file_path_a: string;
-    file_path_b: string;
-}
-
-interface DuplicateResponse {
-    success: boolean;
-    data?: {
-        duplicates: DuplicatePair[];
-    };
-    message?: string;
-}
-
-type DatabaseEngine = 'firebird' | 'postgres' | 'api';
-// NOTE: Keep the database config types below in sync with electron/types.ts.
-
-interface PostgresSslConfig {
-    enabled?: boolean;
-    rejectUnauthorized?: boolean;
-    ca?: string;
-    cert?: string;
-    key?: string;
-}
-
-interface PostgresPoolConfig {
-    min?: number;
-    max?: number;
-    idleTimeoutMillis?: number;
-    connectionTimeoutMillis?: number;
-}
-
-interface PostgresConfig {
-    host: string;
-    port: number;
-    database: string;
-    user: string;
-    password?: string;
-    ssl?: boolean | PostgresSslConfig;
-    pool?: PostgresPoolConfig;
-}
-
-interface FirebirdDatabaseConfig {
-    engine?: Extract<DatabaseEngine, 'firebird'>;
-    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
-    provider?: 'firebird';
-    host?: string;
-    port?: number;
-    path?: string;
-    user?: string;
-    password?: string;
-}
-
-interface PostgresDatabaseConfig {
-    engine: Extract<DatabaseEngine, 'postgres'>;
-    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
-    provider?: 'postgres';
-    postgres: PostgresConfig;
-}
-
-interface ApiDatabaseConfig {
-    engine: Extract<DatabaseEngine, 'api'>;
-    /** @deprecated Prefer `engine`. Kept for backward compatibility with older configs/branches. */
-    provider?: 'api';
-    api: {
-        url?: string;
-        timeout?: number;
-        dialect?: 'firebird' | 'postgres';
-        sqlDialect?: 'firebird' | 'postgres';
-    };
-}
-
-type DatabaseConfig = FirebirdDatabaseConfig | PostgresDatabaseConfig | ApiDatabaseConfig;
-
-interface AppConfig {
-    database?: DatabaseConfig;
-    dev?: {
-        url?: string;
-    };
-    api?: {
-        url?: string;
-        port?: number;
-        host?: string;
-    };
-    firebird?: {
-        path?: string;
-    };
-    selection?: Record<string, unknown>;
-    paths?: {
-        thumbnail_path_remap?: Array<{ from: string; to: string }>;
-        remap_legacy_image_scoring_thumbnails?: boolean;
-        thumbnail_base_dir?: string;
-    };
-    lightModeRootFolder?: string;
-    sync?: {
-        destinationRoot?: string;
-    };
-    backup?: {
-        minScore?: number;
-        similarityThreshold?: number;
-        maxInstances?: number;
-    };
-    [key: string]: unknown;
-}
-
-// -- Backup Feature Types --
-
-interface BackupTargetInfo {
-    exists: boolean;
-    imageCount: number;
-    lastBackup: string | null;
-    bytes: number;
-}
-
-interface BackupManifestEntry {
-    id: number;
-    relPath: string;
-    score: number;
-    size: number;
-    hash: string;
-}
-
-interface BackupManifest {
-    updatedAt: string;
-    images: BackupManifestEntry[];
-}
-
-interface BackupProgress {
-    phase: 'scanning' | 'deduplicating' | 'calculating' | 'copying' | 'cleaning' | 'done';
-    current: number;
-    total: number;
-    detail?: string;
-}
-
-interface BackupResult {
-    copied: number;
-    skipped: number;
-    deduplicated: number;
-    errors: string[];
-    staleRemoved: number;
-    droppedForSpace: number;
-}
-
-
-interface FsDirEntry {
-    name: string;
-    path: string;
-}
-
-interface FsReadDirResult {
-    dirPath: string;
-    directories: FsDirEntry[];
-    images: FsDirEntry[];
-    totalImageCount: number;
-    rootPath: string;
-}
-
-interface FileImageMetadataDetail {
-    title?: string;
-    description?: string;
-    keywords?: string;
-    rating: number;
-    label: string | null;
-    exif_iso?: number | null;
-    exif_shutter?: string | null;
-    exif_aperture?: string | null;
-    exif_focal_length?: string | null;
-    exif_model?: string | null;
-    exif_lens_model?: string | null;
-}
-
-interface FileImageMetadataResult {
-    tags: Record<string, unknown>;
-    detail: FileImageMetadataDetail;
-}
-
-/** Mirrors `electron/types.ts` ExportImageContext — IPC payload for File → Export. */
-interface ExportImageContext {
-    imageBytes: number[];
-    mimeType: string;
-    fileName: string;
-    id: number;
-    sourcePath: string;
-    imageUuid: string | null;
-    /** True when preview pixels were physically re-oriented to upright during export bake. */
-    pixelNormalizationApplied?: boolean;
-    /** EXIF Orientation read from the preview JPEG before bake (diagnostics). */
-    previewOrientation?: number | string;
-}
+export type {
+    AppConfig,
+    BackupProgress,
+    BackupResult,
+    BackupTargetInfo,
+    DuplicateResponse,
+    ExportImageContext,
+    FileImageMetadataResult,
+    FolderRow,
+    FsReadDirResult,
+    ImageDetail,
+    ImageQueryOptions,
+    ImageRow,
+    ImageUpdates,
+} from '../electron/types';
 
 declare global {
     interface Window {


### PR DESCRIPTION
### Motivation
- Remove duplicated renderer type declarations and establish `electron/types.ts` as the single source of truth to avoid drift. 
- Eliminate legacy Firebird-only branches from the renderer declarations by relying on the canonical shared config types. 
- Prevent accidental divergence between the canonical types and renderer declarations by adding an automated validation step in CI.

### Description
- Refactored `src/electron.d.ts` to `import type` and `export type` the shared IPC/domain types from `electron/types.ts` instead of keeping duplicate local definitions. 
- Removed Firebird-specific / legacy branches from the renderer declarations and now rely on the canonical `AppConfig`/database types exposed by `electron/types.ts`. 
- Added a new validator script at `scripts/check-type-sync.mjs` that checks `src/electron.d.ts` imports/re-exports match the canonical exported types in `electron/types.ts` and fails on mismatches. 
- Wired the new check into `package.json` as the `check:type-sync` script and added a CI step in `.github/workflows/test-and-contract.yml` to run `npm run check:type-sync` immediately after unit tests.

### Testing
- Ran unit tests with `npm run test:run` and all tests passed (26 files, 178 tests). 
- Executed the new validator with `npm run check:type-sync` and it passed. 
- Ran type check with `npx tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4483b9a508323b4420dc3d2307798)