### PR TITLE
Add docs guides index consistency check

### DIFF
--- a/.github/workflows/test-and-contract.yml
+++ b/.github/workflows/test-and-contract.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Check docs guides index completeness (non-blocking)
         id: docs_guides_index
         continue-on-error: true
-        run: npm run docs:check-guides-index
+        run: node scripts/check-guides-index.mjs
 
       - name: Docs guides index warning
         if: steps.docs_guides_index.outcome == 'failure'
         run: |
-          echo "::warning::docs/guides/README.md is out of sync with docs/guides/*.md. Run 'npm run docs:check-guides-index' and update the index links."
+          echo "::warning::docs/guides/README.md is out of sync with docs/guides/*.md. Run 'node scripts/check-guides-index.mjs' and update the index links."
 
       - name: Fetch backend OpenAPI snapshot source
         run: git clone --depth 1 https://github.com/synthet/image-scoring-backend ../image-scoring-backend

--- a/.github/workflows/test-and-contract.yml
+++ b/.github/workflows/test-and-contract.yml
@@ -28,6 +28,16 @@ jobs:
         run: npm run test:run
 
 
+      - name: Check docs guides index completeness (non-blocking)
+        id: docs_guides_index
+        continue-on-error: true
+        run: npm run docs:check-guides-index
+
+      - name: Docs guides index warning
+        if: steps.docs_guides_index.outcome == 'failure'
+        run: |
+          echo "::warning::docs/guides/README.md is out of sync with docs/guides/*.md. Run 'npm run docs:check-guides-index' and update the index links."
+
       - name: Fetch backend OpenAPI snapshot source
         run: git clone --depth 1 https://github.com/synthet/image-scoring-backend ../image-scoring-backend
 

--- a/.github/workflows/test-and-contract.yml
+++ b/.github/workflows/test-and-contract.yml
@@ -44,10 +44,11 @@ jobs:
       # Canonical gate: contract:check fails when generated contract files drift from source API types.
       # This blocks merges until contract artifacts are updated and committed.
       - name: Enforce API contract sync
+        id: contract_check
         run: npm run contract:check
 
       - name: Contract drift merge-block note
-        if: failure()
+        if: steps.contract_check.outcome == 'failure'
         run: |
           echo "::error::Contract drift detected. Run 'npm run contract:update', commit generated contract changes, and push again."
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,6 +3,7 @@
 Development workflows and maintenance recommendations.
 
 - [01 - Lint Recommendations](01-lint-recommendations.md) - Code quality and ESLint fix guidance (see also [Reports: ESLint Audit](../reports/03-eslint-audit-2026-03.md) for full audit)
+- [02 - API Backend Config](02-api-backend-config.md) - Backend URL/config options and health-check guidance for local/dev runs
 - [03 - Testing and Coverage Guide](03-testing-and-coverage.md) - Test commands, coverage artifacts, and threshold ratcheting policy
 
 [← Back to Documentation Index](../README.md)

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "contract:validate": "node scripts/validate-api-types.mjs",
     "dev:browser": "npm run dev:web",
     "server": "npx tsx server/index.ts",
-    "start:browser": "npm run build && node dist-server/index.js",
-    "docs:check-guides-index": "node scripts/check-guides-index.mjs"
+    "start:browser": "npm run build && node dist-server/index.js"
   },
   "build": {
     "forceCodeSigning": false,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "contract:validate": "node scripts/validate-api-types.mjs",
     "dev:browser": "npm run dev:web",
     "server": "npx tsx server/index.ts",
-    "start:browser": "npm run build && node dist-server/index.js"
+    "start:browser": "npm run build && node dist-server/index.js",
+    "docs:check-guides-index": "node scripts/check-guides-index.mjs"
   },
   "build": {
     "forceCodeSigning": false,

--- a/scripts/check-guides-index.mjs
+++ b/scripts/check-guides-index.mjs
@@ -1,0 +1,31 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const docsGuidesDir = path.resolve('docs/guides');
+const indexPath = path.join(docsGuidesDir, 'README.md');
+
+const allGuideFiles = (await readdir(docsGuidesDir))
+  .filter((file) => file.endsWith('.md') && file !== 'README.md')
+  .sort();
+
+const readmeContent = await readFile(indexPath, 'utf8');
+const linkedTargets = new Set(
+  [...readmeContent.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)]
+    .map(([, target]) => target.trim())
+    .filter((target) => !target.startsWith('#'))
+    .map((target) => target.split('#')[0])
+    .map((target) => target.replace(/^\.\//, '')),
+);
+
+const missing = allGuideFiles.filter((file) => !linkedTargets.has(file));
+
+if (missing.length > 0) {
+  console.error('docs/guides/README.md is missing links to:');
+  for (const file of missing) {
+    console.error(`- ${file}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Guides index is complete: ${allGuideFiles.length} guide file(s) linked.`);


### PR DESCRIPTION
### Motivation

- Ensure every `docs/guides/*.md` file (excluding `README.md`) is discoverable from the guides index to prevent drift and missing documentation links. 
- Make the new `02-api-backend-config.md` guide visible from the guides index so backend config guidance is discoverable. 
- Surface index inconsistencies early in CI as a non-blocking warning so maintainers can fix links without blocking merges.

### Description

- Add `docs/guides/README.md` entry for `02-api-backend-config.md` to make the guide discoverable. 
- Add a lightweight verifier script at `scripts/check-guides-index.mjs` that enumerates `docs/guides/*.md`, parses links in the index, and fails when any guide is missing. 
- Expose the checker via `package.json` as the npm script `docs:check-guides-index`. 
- Wire the check into `.github/workflows/test-and-contract.yml` as a `continue-on-error: true` step and emit a warning when it fails so the check is non-blocking initially.

### Testing

- Ran `npm run docs:check-guides-index` which completed successfully and reported the index is complete. 
- The docs check step is added to CI as non-blocking and will surface warnings in workflow runs (no blocking failures introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4485353748323b0e212c9fbac0db9)