### PR TITLE
Document and test legacy backend lock path precedence

### DIFF
--- a/docs/guides/02-api-backend-config.md
+++ b/docs/guides/02-api-backend-config.md
@@ -7,7 +7,11 @@ This gallery can discover the Python backend automatically, but you can also pin
 The backend base URL is resolved in this order:
 
 1. **`config.api.url`**: exact base URL, highest priority
-2. **Sibling backend lock file**: `webui.lock` / `webui-debug.lock` from `image-scoring-backend`
+2. **Sibling backend lock file** (first existing file wins), checked in this exact order:
+   - `../image-scoring-backend/webui.lock`
+   - `../image-scoring-backend/webui-debug.lock`
+   - `../image-scoring/webui.lock` *(legacy repo name)*
+   - `../image-scoring/webui-debug.lock` *(legacy repo name)*
 3. **Fallback host/port**: `config.api.host` + `config.api.port`
 4. **Default fallback**: `http://127.0.0.1:7860`
 
@@ -52,3 +56,5 @@ Automatic lock-file discovery checks these sibling locations relative to the gal
 
 - `../image-scoring-backend/webui.lock`
 - `../image-scoring-backend/webui-debug.lock`
+- `../image-scoring/webui.lock` *(legacy path retained for backwards compatibility)*
+- `../image-scoring/webui-debug.lock` *(legacy path retained for backwards compatibility)*

--- a/electron/apiUrlResolver.test.ts
+++ b/electron/apiUrlResolver.test.ts
@@ -40,6 +40,54 @@ describe('resolveBaseUrl', () => {
     expect(mockFs.readFileSync).toHaveBeenCalled();
   });
 
+  it('prefers image-scoring-backend lock files over legacy image-scoring lock files', () => {
+    const config: AppConfig = {};
+    mockFs.existsSync.mockImplementation((filePath: string) => {
+      return (
+        filePath.endsWith(path.join('image-scoring-backend', 'webui.lock')) ||
+        filePath.endsWith(path.join('image-scoring', 'webui.lock'))
+      );
+    });
+    mockFs.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith(path.join('image-scoring-backend', 'webui.lock'))) {
+        return JSON.stringify({ port: 8100 });
+      }
+      if (filePath.endsWith(path.join('image-scoring', 'webui.lock'))) {
+        return JSON.stringify({ port: 8200 });
+      }
+      return JSON.stringify({});
+    });
+
+    const projectRoot = path.resolve(__dirname, '..');
+    const result = resolveBaseUrl(config, {
+      projectRoot,
+      fs: mockFs,
+    });
+
+    expect(result).toBe('http://127.0.0.1:8100');
+  });
+
+  it('uses legacy image-scoring lock files when image-scoring-backend lock files are absent', () => {
+    const config: AppConfig = {};
+    mockFs.existsSync.mockImplementation((filePath: string) => {
+      return filePath.endsWith(path.join('image-scoring', 'webui-debug.lock'));
+    });
+    mockFs.readFileSync.mockImplementation((filePath: string) => {
+      if (filePath.endsWith(path.join('image-scoring', 'webui-debug.lock'))) {
+        return JSON.stringify({ port: 8300 });
+      }
+      return JSON.stringify({});
+    });
+
+    const projectRoot = path.resolve(__dirname, '..');
+    const result = resolveBaseUrl(config, {
+      projectRoot,
+      fs: mockFs,
+    });
+
+    expect(result).toBe('http://127.0.0.1:8300');
+  });
+
   it('uses default host:port when no config and no lock file', () => {
     const config: AppConfig = {};
     mockFs.existsSync.mockReturnValue(false);

--- a/electron/apiUrlResolver.ts
+++ b/electron/apiUrlResolver.ts
@@ -31,6 +31,7 @@ export function resolveBaseUrl(config: AppConfig, options?: ResolveOptions): str
     const locks = [
       pathMod.join(projectsDir, 'image-scoring-backend', 'webui.lock'),
       pathMod.join(projectsDir, 'image-scoring-backend', 'webui-debug.lock'),
+      // Legacy sibling repo name retained for backwards compatibility.
       pathMod.join(projectsDir, 'image-scoring', 'webui.lock'),
       pathMod.join(projectsDir, 'image-scoring', 'webui-debug.lock'),
     ];


### PR DESCRIPTION
### Motivation
- Preserve backward compatibility by keeping legacy `../image-scoring/*lock` probing so sibling checkouts with the older repo name continue to be discovered. 
- Make the discovery precedence explicit in docs and tests to avoid ambiguity about which lock file wins when multiple are present.

### Description
- Retained legacy lock-file probes in `electron/apiUrlResolver.ts` and added an inline comment explaining the backwards-compatibility intent. 
- Updated `docs/guides/02-api-backend-config.md` to list the exact lock-file probe order and state that the first existing file wins, including the legacy `../image-scoring/*lock` paths. 
- Added tests to `electron/apiUrlResolver.test.ts` that assert `image-scoring-backend` lock files are preferred over legacy `image-scoring` lock files and that legacy lock files are used when backend lock files are absent. 

### Testing
- Ran `npm run test:run -- electron/apiUrlResolver.test.ts` using Vitest and the added test file. 
- Test run succeeded: `Test Files 1 passed (1)` and `Tests 9 passed (9)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4484340288323b26fd7eb0b642176)