### PR TITLE
docs: update Linux Electron run instructions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,13 +60,15 @@ The `.cursor/mcp.json` file uses the **`imgscore-el-*`** prefix so server names 
 
 ### Running the Electron app on Linux (Cloud VM)
 
-- The `npm run dev` script includes `db:start` which calls a **PowerShell script** (`scripts/start_db.ps1`) — this is Windows-only and will fail on Linux. Instead, run the components separately:
-  1. `npm run dev:web` — starts the Vite dev server
-  2. `npx tsc -p electron/tsconfig.json` — compiles Electron main process TypeScript
-  3. `ELECTRON_IS_DEV=1 npx electron .` — launches Electron (set env var directly; `cross-env` may not be on PATH as a global binary)
-- The app may show a connection error at startup if PostgreSQL or the backend API URL is unreachable in the VM. The UI can still load for layout and static testing.
-- `cross-env` is installed as a devDependency but not globally, so use `ELECTRON_IS_DEV=1` env prefix directly instead of `cross-env ELECTRON_IS_DEV=1`.
+- Current dev composition is already Linux-friendly via npm scripts:
+  1. `npm run server` — starts the backend/API process expected by the gallery
+  2. `vite` — starts the Vite dev server on `http://localhost:5173`
+  3. `npm run dev:electron` — waits for Vite, compiles Electron TS, and launches Electron in dev mode
+- `npm run dev` runs those three commands concurrently (`server`, `vite`, `dev:electron`) and is the easiest default for local Linux/Cloud VM use.
+- If you need renderer-only work, use `npm run dev:web` (server + Vite) without launching Electron.
+- The app may still show a connection error at startup if PostgreSQL or the backend API URL is unreachable in the VM. The UI can still load for layout and static testing.
 - dbus errors in Electron logs (e.g. `Failed to connect to the bus`) are harmless in a headless/container Linux environment.
+- _Verified against `package.json` scripts on 2026-04-19._
 
 ### Lockfile
 


### PR DESCRIPTION
### Motivation

- Replace an outdated Windows-specific note about `db:start`/PowerShell with accurate Linux-friendly run instructions that reflect the repository's current npm scripts. 
- Make the recommended local dev composition explicit so contributors on Linux/Cloud VMs can run the gallery reliably.
- Add an explicit verification timestamp to reduce future staleness and make it obvious when the doc was last checked against `package.json`.

### Description

- Replaced the previous Windows-only guidance in the "Running the Electron app on Linux (Cloud VM)" section with a short, current composition listing `npm run server`, `vite`, and `npm run dev:electron`.
- Documented that `npm run dev` runs those three commands concurrently and kept the `npm run dev:web` renderer-only option.
- Preserved notes about backend connectivity errors and harmless `dbus` warnings in headless/container environments.
- Added a staleness marker: "_Verified against `package.json` scripts on 2026-04-19._".

### Testing

- Verified relevant occurrences in `AGENTS.md` and `package.json` using `rg` which succeeded. 
- Inspected the updated documentation block with `sed`/`nl` to confirm the new content is present and correctly formatted. 
- Cross-checked the listed npm scripts in `package.json` to ensure the docs reflect the actual script names and behavior, and found no mismatches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e448416bac8323bf2c1c05254060c8)