### PR TITLE
Clarify Firebird normalization boundary and add end-to-end connector test

### DIFF
--- a/docs/architecture/02-database-design.md
+++ b/docs/architecture/02-database-design.md
@@ -14,7 +14,7 @@ Migrate to **PostgreSQL + pgvector** as a coordinated platform move across both 
 ## What was done
 
 1. **Backend (Phase 3)**: Python scoring pipeline switched to PostgreSQL. All ~60 DB functions route to PG. SQL auto-translation layer handles legacy Firebird syntax.
-2. **Electron (Phase 4)**: `electron/db/provider.ts` provides a connector abstraction. `node-firebird` dependency removed; `pg` is the production driver. Legacy `engine: "firebird"` config values automatically map to the Postgres connector.
+2. **Electron (Phase 4)**: `electron/db/provider.ts` provides a connector abstraction. `node-firebird` dependency removed; `pg` is the production driver. Legacy `engine: "firebird"` / `provider: "firebird"` values are mapped to Postgres **only in config normalization** (`normalizeAppConfig` in `electron/config.ts`). The provider layer (`createDatabaseConnector` in `electron/db/provider.ts`) intentionally accepts only normalized engines (`postgres`/`api`) and rejects raw `firebird` values.
 3. **Data migration**: Bulk migration script (`scripts/python/migrate_firebird_to_postgres.py`) migrated all data including embeddings (Firebird BLOB → `vector(1280)` with HNSW cosine index).
 
 ## Current stack

--- a/electron/db/provider.test.ts
+++ b/electron/db/provider.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import type { DatabaseConfig } from '../types';
+import { loadAppConfig } from '../config';
 import {
     createDatabaseConnector,
     ApiConnector,
@@ -47,7 +51,7 @@ describe('Database Connector Abstraction', () => {
             expect(connector.type).toBe('api');
         });
 
-        it('should throw error for decommissioned "firebird" engine', () => {
+        it('provider rejects raw "firebird" engine (no normalization at provider layer)', () => {
             const config = {
                 dbConfig: {
                     engine: 'firebird',
@@ -68,6 +72,31 @@ describe('Database Connector Abstraction', () => {
             );
             expect(connector).toBeInstanceOf(PostgresConnector);
             expect(connector.type).toBe('postgres');
+        });
+
+        it('normalizer maps firebird->postgres before provider: config load to connector creation', () => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gallery-db-config-'));
+            const configPath = path.join(tempDir, 'config.json');
+            try {
+                fs.writeFileSync(configPath, JSON.stringify({
+                    database: {
+                        provider: 'firebird',
+                        postgres: { host: 'localhost', port: 5432, database: 'test', user: 'user' },
+                    }
+                }));
+
+                const appConfig = loadAppConfig(configPath);
+                expect(appConfig.database?.engine).toBe('postgres');
+
+                const connector = createDatabaseConnector({
+                    dbConfig: appConfig.database as DatabaseConfig
+                });
+
+                expect(connector).toBeInstanceOf(PostgresConnector);
+                expect(connector.type).toBe('postgres');
+            } finally {
+                fs.rmSync(tempDir, { recursive: true, force: true });
+            }
         });
     });
 


### PR DESCRIPTION
### Motivation
- Establish a clear boundary between config normalization and the DB provider so legacy Firebird values are handled in one place. 
- Lock intended behavior with a test that covers the path from config load to connector creation to avoid regressions.

### Description
- Update docs in `docs/architecture/02-database-design.md` to state that legacy `engine: "firebird"` / `provider: "firebird"` values are mapped to Postgres only in config normalization (`normalizeAppConfig` in `electron/config.ts`) and that the provider (`createDatabaseConnector` in `electron/db/provider.ts`) rejects raw `firebird` values. 
- Revise `electron/db/provider.test.ts` to rename the legacy-engine test to `provider rejects raw "firebird" engine (no normalization at provider layer)` and assert the provider remains strict. 
- Add an integration-style test in `electron/db/provider.test.ts` that writes a temporary `config.json` containing legacy `provider: 'firebird'`, loads it with `loadAppConfig`, asserts normalization to `engine: 'postgres'`, then calls `createDatabaseConnector` and verifies a `PostgresConnector` is returned (test uses `fs`, `os`, `path` and cleans up in `finally`).

### Testing
- Ran `npm run test:run -- electron/db/provider.test.ts` which executed the updated file under Vitest. 
- Result: test run succeeded with `1` test file and `11` tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4483e0e2c8323b8324f50b55591ba)