### PR TITLE
Harden database config tests and add api-mode normalization test

### DIFF
--- a/electron/config.examples.test.ts
+++ b/electron/config.examples.test.ts
@@ -3,6 +3,27 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeAppConfig } from './config';
+import type { ApiDatabaseConfig, PostgresDatabaseConfig } from './types';
+
+function isPostgresDatabaseConfig(database: unknown): database is PostgresDatabaseConfig {
+  return Boolean(
+    database
+    && typeof database === 'object'
+    && 'engine' in database
+    && (database as { engine?: unknown }).engine === 'postgres'
+    && 'postgres' in database,
+  );
+}
+
+function isApiDatabaseConfig(database: unknown): database is ApiDatabaseConfig {
+  return Boolean(
+    database
+    && typeof database === 'object'
+    && 'engine' in database
+    && (database as { engine?: unknown }).engine === 'api'
+    && 'api' in database,
+  );
+}
 
 describe('config examples', () => {
   function loadExample(filename: string) {
@@ -13,18 +34,16 @@ describe('config examples', () => {
 
   it('normalizes config.example.json to postgres defaults with nested postgres config', () => {
     const normalized = loadExample('config.example.json');
-
     const database = normalized.database;
-    if (!database) {
-      throw new Error('Expected database configuration in config.example.json');
+
+    expect(database).toBeDefined();
+    expect(isPostgresDatabaseConfig(database)).toBe(true);
+
+    if (!isPostgresDatabaseConfig(database)) {
+      return;
     }
 
     expect(database.engine).toBe('postgres');
-
-    if (database.engine !== 'postgres' || !('postgres' in database)) {
-      throw new Error('Expected postgres database configuration in config.example.json');
-    }
-
     expect(database.provider).toBe('postgres');
     expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
@@ -37,18 +56,16 @@ describe('config examples', () => {
 
   it('normalizes environment.example.json with postgres shape and defaults', () => {
     const normalized = loadExample('environment.example.json');
-
     const database = normalized.database;
-    if (!database) {
-      throw new Error('Expected database configuration in environment.example.json');
+
+    expect(database).toBeDefined();
+    expect(isPostgresDatabaseConfig(database)).toBe(true);
+
+    if (!isPostgresDatabaseConfig(database)) {
+      return;
     }
 
     expect(database.engine).toBe('postgres');
-
-    if (database.engine !== 'postgres' || !('postgres' in database)) {
-      throw new Error('Expected postgres database configuration in environment.example.json');
-    }
-
     expect(database.provider).toBe('postgres');
     expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
@@ -70,18 +87,16 @@ describe('config examples', () => {
         },
       },
     });
-
     const database = normalized.database;
-    if (!database) {
-      throw new Error('Expected database configuration for api-mode input');
+
+    expect(database).toBeDefined();
+    expect(isApiDatabaseConfig(database)).toBe(true);
+
+    if (!isApiDatabaseConfig(database)) {
+      return;
     }
 
     expect(database.engine).toBe('api');
-
-    if (database.engine !== 'api' || !('api' in database)) {
-      throw new Error('Expected api database configuration for api-mode input');
-    }
-
     expect(database.provider).toBe('api');
     expect(database.api).toMatchObject({
       url: 'http://localhost:8000',

--- a/electron/config.examples.test.ts
+++ b/electron/config.examples.test.ts
@@ -14,9 +14,19 @@ describe('config examples', () => {
   it('normalizes config.example.json to postgres defaults with nested postgres config', () => {
     const normalized = loadExample('config.example.json');
 
-    expect(normalized.database.engine).toBe('postgres');
-    expect(normalized.database.provider).toBe('postgres');
-    expect(normalized.database.postgres).toMatchObject({
+    const database = normalized.database;
+    if (!database) {
+      throw new Error('Expected database configuration in config.example.json');
+    }
+
+    expect(database.engine).toBe('postgres');
+
+    if (database.engine !== 'postgres' || !('postgres' in database)) {
+      throw new Error('Expected postgres database configuration in config.example.json');
+    }
+
+    expect(database.provider).toBe('postgres');
+    expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
       port: 5432,
       database: 'image_scoring',
@@ -28,15 +38,57 @@ describe('config examples', () => {
   it('normalizes environment.example.json with postgres shape and defaults', () => {
     const normalized = loadExample('environment.example.json');
 
-    expect(normalized.database.engine).toBe('postgres');
-    expect(normalized.database.provider).toBe('postgres');
-    expect(normalized.database.postgres).toMatchObject({
+    const database = normalized.database;
+    if (!database) {
+      throw new Error('Expected database configuration in environment.example.json');
+    }
+
+    expect(database.engine).toBe('postgres');
+
+    if (database.engine !== 'postgres' || !('postgres' in database)) {
+      throw new Error('Expected postgres database configuration in environment.example.json');
+    }
+
+    expect(database.provider).toBe('postgres');
+    expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
       port: 5432,
       database: 'image_scoring',
       user: 'postgres',
       password: 'postgres',
     });
-    expect(normalized.database).not.toHaveProperty('api');
+    expect(database).not.toHaveProperty('api');
+  });
+
+  it('normalizes api-mode config shape with api-specific fields', () => {
+    const normalized = normalizeAppConfig({
+      database: {
+        engine: 'api',
+        api: {
+          url: 'http://localhost:8000',
+          timeout: 5000,
+        },
+      },
+    });
+
+    const database = normalized.database;
+    if (!database) {
+      throw new Error('Expected database configuration for api-mode input');
+    }
+
+    expect(database.engine).toBe('api');
+
+    if (database.engine !== 'api' || !('api' in database)) {
+      throw new Error('Expected api database configuration for api-mode input');
+    }
+
+    expect(database.provider).toBe('api');
+    expect(database.api).toMatchObject({
+      url: 'http://localhost:8000',
+      timeout: 5000,
+      dialect: 'postgres',
+      sqlDialect: 'postgres',
+    });
+    expect(database).not.toHaveProperty('postgres');
   });
 });


### PR DESCRIPTION
### Motivation
- Make the existing config example tests more robust against missing or unexpected `database` shapes when normalizing with `normalizeAppConfig`.
- Add coverage for the `api`-mode database shape to ensure API-specific fields and defaults are applied.

### Description
- Replace repeated `normalized.database` access with a local `database` variable and add explicit existence checks that throw helpful errors if missing.
- Add guards that verify the `engine` before accessing engine-specific properties to avoid unsafe property access.
- Update assertions for `config.example.json` and `environment.example.json` to use the guarded `database` variable and keep the expectation that `api` is not present for postgres examples.
- Add a new test that constructs an `api`-mode input for `normalizeAppConfig` and asserts `database.provider` and `database.api` fields (including default `dialect` and `sqlDialect`) and that no `postgres` property exists.

### Testing
- Ran the unit test suite with `vitest` against the modified `electron/config.examples.test.ts` file. All tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e588e50d408323ab039abaa5f5d0e9)