### PR TITLE
Tighten normalized config typing and database-mode assertions

### DIFF
--- a/electron/config.examples.test.ts
+++ b/electron/config.examples.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeAppConfig } from './config';
+import type { ApiDatabaseConfig, PostgresDatabaseConfig } from './types';
 
 describe('config examples', () => {
   function loadExample(filename: string) {
@@ -13,30 +14,56 @@ describe('config examples', () => {
 
   it('normalizes config.example.json to postgres defaults with nested postgres config', () => {
     const normalized = loadExample('config.example.json');
+    const database = normalized.database as PostgresDatabaseConfig;
 
-    expect(normalized.database.engine).toBe('postgres');
-    expect(normalized.database.provider).toBe('postgres');
-    expect(normalized.database.postgres).toMatchObject({
+    expect(database.engine).toBe('postgres');
+    expect(database.provider).toBe('postgres');
+    expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
       port: 5432,
       database: 'image_scoring',
       user: 'postgres',
       password: 'postgres',
     });
+    expect(database).not.toHaveProperty('api');
   });
 
   it('normalizes environment.example.json with postgres shape and defaults', () => {
     const normalized = loadExample('environment.example.json');
+    const database = normalized.database as PostgresDatabaseConfig;
 
-    expect(normalized.database.engine).toBe('postgres');
-    expect(normalized.database.provider).toBe('postgres');
-    expect(normalized.database.postgres).toMatchObject({
+    expect(database.engine).toBe('postgres');
+    expect(database.provider).toBe('postgres');
+    expect(database.postgres).toMatchObject({
       host: '127.0.0.1',
       port: 5432,
       database: 'image_scoring',
       user: 'postgres',
       password: 'postgres',
     });
-    expect(normalized.database).not.toHaveProperty('api');
+    expect(database).not.toHaveProperty('api');
+  });
+
+  it('normalizes api mode without exposing postgres fields', () => {
+    const normalized = normalizeAppConfig({
+      database: {
+        engine: 'api',
+        api: {
+          url: 'http://127.0.0.1:7860',
+          timeout: 5000,
+        },
+      },
+    });
+    const database = normalized.database as ApiDatabaseConfig;
+
+    expect(database.engine).toBe('api');
+    expect(database.provider).toBe('api');
+    expect(database.api).toMatchObject({
+      url: 'http://127.0.0.1:7860',
+      timeout: 5000,
+      dialect: 'postgres',
+      sqlDialect: 'postgres',
+    });
+    expect(database).not.toHaveProperty('postgres');
   });
 });

--- a/electron/config.ts
+++ b/electron/config.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type {
     AppConfig,
+    NormalizedAppConfig,
     DatabaseEngine,
     PostgresDatabaseConfig,
     PostgresPoolConfig,
@@ -80,7 +81,7 @@ export function validatePostgresConfig(databaseConfig: JsonRecord): PostgresConf
     return normalized;
 }
 
-export function normalizeAppConfig(rawConfig: unknown): AppConfig {
+export function normalizeAppConfig(rawConfig: unknown): NormalizedAppConfig {
     const cfg = isRecord(rawConfig) ? { ...rawConfig } : {};
     const rawDatabase = isRecord(cfg.database) ? { ...cfg.database } : {};
     const engine = getEngineFromDatabaseConfig(rawDatabase);
@@ -118,7 +119,7 @@ export function getEnvironmentPath(fromDirname: string): string {
     return path.resolve(path.join(fromDirname, '../environment.json'));
 }
 
-export function loadAppConfig(configPath: string): AppConfig {
+export function loadAppConfig(configPath: string): NormalizedAppConfig {
     try {
         const baseRaw = fs.existsSync(configPath)
             ? JSON.parse(fs.readFileSync(configPath, 'utf8'))

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -149,6 +149,11 @@ export interface ApiDatabaseConfig {
 
 export type DatabaseConfig = PostgresDatabaseConfig | ApiDatabaseConfig;
 
+/** Normalized config returned by config loaders/normalizers. */
+export type NormalizedAppConfig = Omit<AppConfig, 'database'> & {
+    database: DatabaseConfig;
+};
+
 export interface AppConfig {
     database?: DatabaseConfig;
     dev?: {

--- a/environment.example.json
+++ b/environment.example.json
@@ -1,6 +1,7 @@
 {
     "_comment": "Copy to environment.json and set machine-specific values. environment.json is gitignored and overrides matching keys from config.json.",
     "database": {
+        "engine": "postgres",
         "postgres": {
             "host": "127.0.0.1",
             "port": 5432,


### PR DESCRIPTION
### Motivation
- The normalizer always produces a `database` entry but its return type used `AppConfig` where `database` is optional, causing callers/tests to treat `database` as possibly absent.
- Tests should assert mode-specific interfaces (postgres vs api) and not rely on fields that belong to the other mode.
- Prevent future accidental access to `postgres` properties when running in `api` mode by adding a negative assertion.
- Make example fixtures explicitly map to a single database mode so each fixture’s assertions are unambiguous.

### Description
- Added `NormalizedAppConfig` to `electron/types.ts` to represent the post-normalization contract where `database` is required and always present.
- Changed `normalizeAppConfig` and `loadAppConfig` signatures in `electron/config.ts` to return `NormalizedAppConfig` instead of `AppConfig`.
- Updated `electron/config.examples.test.ts` to cast `normalized.database` to `PostgresDatabaseConfig` or `ApiDatabaseConfig` per scenario, assert mode-specific properties, and include negative assertions ensuring the other mode’s fields are absent.
- Made `environment.example.json` explicitly declare `database.engine: "postgres"` so the example fixture maps to a clear postgres mode.

### Testing
- Ran the example tests with `npm run test:run -- electron/config.examples.test.ts` and all tests passed (3 tests, 1 file).
- Ran TypeScript checks with `npx tsc --noEmit` and the type check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e588e661a08323af23c62e5d3eb538)