### PR TITLE
test: safely narrow database union in config example tests

### DIFF
--- a/electron/config.examples.test.ts
+++ b/electron/config.examples.test.ts
@@ -14,34 +14,44 @@ describe('config examples', () => {
 
   it('normalizes config.example.json to postgres defaults with nested postgres config', () => {
     const normalized = loadExample('config.example.json');
-    const database = normalized.database as PostgresDatabaseConfig;
 
-    expect(database.engine).toBe('postgres');
-    expect(database.provider).toBe('postgres');
-    expect(database.postgres).toMatchObject({
-      host: '127.0.0.1',
-      port: 5432,
-      database: 'image_scoring',
-      user: 'postgres',
-      password: 'postgres',
-    });
-    expect(database).not.toHaveProperty('api');
+    expect(normalized.database).toBeDefined();
+    expect(normalized.database?.engine).toBe('postgres');
+
+    if (normalized.database?.engine === 'postgres') {
+      const database = normalized.database as PostgresDatabaseConfig;
+
+      expect(database.provider).toBe('postgres');
+      expect(database.postgres).toMatchObject({
+        host: '127.0.0.1',
+        port: 5432,
+        database: 'image_scoring',
+        user: 'postgres',
+        password: 'postgres',
+      });
+      expect(database).not.toHaveProperty('api');
+    }
   });
 
   it('normalizes environment.example.json with postgres shape and defaults', () => {
     const normalized = loadExample('environment.example.json');
-    const database = normalized.database as PostgresDatabaseConfig;
 
-    expect(database.engine).toBe('postgres');
-    expect(database.provider).toBe('postgres');
-    expect(database.postgres).toMatchObject({
-      host: '127.0.0.1',
-      port: 5432,
-      database: 'image_scoring',
-      user: 'postgres',
-      password: 'postgres',
-    });
-    expect(database).not.toHaveProperty('api');
+    expect(normalized.database).toBeDefined();
+    expect(normalized.database?.engine).toBe('postgres');
+
+    if (normalized.database?.engine === 'postgres') {
+      const database = normalized.database as PostgresDatabaseConfig;
+
+      expect(database.provider).toBe('postgres');
+      expect(database.postgres).toMatchObject({
+        host: '127.0.0.1',
+        port: 5432,
+        database: 'image_scoring',
+        user: 'postgres',
+        password: 'postgres',
+      });
+      expect(database).not.toHaveProperty('api');
+    }
   });
 
   it('normalizes api mode without exposing postgres fields', () => {
@@ -54,16 +64,21 @@ describe('config examples', () => {
         },
       },
     });
-    const database = normalized.database as ApiDatabaseConfig;
 
-    expect(database.engine).toBe('api');
-    expect(database.provider).toBe('api');
-    expect(database.api).toMatchObject({
-      url: 'http://127.0.0.1:7860',
-      timeout: 5000,
-      dialect: 'postgres',
-      sqlDialect: 'postgres',
-    });
-    expect(database).not.toHaveProperty('postgres');
+    expect(normalized.database).toBeDefined();
+    expect(normalized.database?.engine).toBe('api');
+
+    if (normalized.database?.engine === 'api') {
+      const database = normalized.database as ApiDatabaseConfig;
+
+      expect(database.provider).toBe('api');
+      expect(database.api).toMatchObject({
+        url: 'http://127.0.0.1:7860',
+        timeout: 5000,
+        dialect: 'postgres',
+        sqlDialect: 'postgres',
+      });
+      expect(database).not.toHaveProperty('postgres');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- updated `electron/config.examples.test.ts` to avoid direct postgres/api union property reads before narrowing
- added explicit `normalized.database` existence checks and engine assertions before any mode-specific expectations
- moved postgres-only and api-only expectations inside guarded `if (engine === ...)` branches

## Why
This keeps test intent unchanged while making union-type access safe and explicit, preventing failures from direct mode-specific access on the discriminated union.

## Validation
- `npm run test:run -- electron/config.examples.test.ts` ✅
- `npm run contract:check` ⚠️ fails due to missing sibling backend OpenAPI file at `/workspace/image-scoring-backend/openapi.json` (environment dependency)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58ced2f3c8323b6a69835ac0179ac)