### PR TITLE
Fix main-process config typing for Electron TypeScript build

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,7 @@ import { ExifTool } from 'exiftool-vendored';
 import { ApiService } from './apiService';
 import {
     ExportImageContext,
+    type AppConfig,
     type FileImageMetadataDetail,
     type FileImageMetadataResult,
     type FsDirEntry,
@@ -650,7 +651,7 @@ protocol.registerSchemesAsPrivileged([
 ]);
 
 // Load configuration
-function loadConfig() {
+function loadConfig(): AppConfig {
     const configPath = getConfigPath(__dirname);
     return loadAppConfig(configPath);
 }


### PR DESCRIPTION
### Motivation
- The Electron main process inferred `config` as `{}` under strict TypeScript, causing `TS2339` errors when accessing nested fields like `dev.url`, `paths.thumbnail_base_dir`, `sync.destinationRoot`, and `api.*` during the dev build.

### Description
- Import the `AppConfig` type and annotate `loadConfig` to return `AppConfig` in `electron/main.ts` so configuration values are correctly typed and properties are recognized by the compiler.

### Testing
- Ran TypeScript build with `npx tsc -p electron/tsconfig.json --pretty false`, which completed without TypeScript errors (only an unrelated npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58d45436883239cccb13597165276)