### PR TITLE
refactor(db): cut over keyword reads to normalized image_keywords/keywords_dim

### DIFF
--- a/electron/db.getStacks.test.ts
+++ b/electron/db.getStacks.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+  getConfigPath: vi.fn(() => '/tmp/config.json'),
+  loadAppConfig: vi.fn(() => ({
+    database: { engine: 'api', api: { url: 'http://127.0.0.1:7860' } },
+  })),
+}));
+
+vi.mock('./db/provider', () => ({
+  createDatabaseConnector: vi.fn(() => ({
+    connect: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    verifyStartup: vi.fn().mockResolvedValue(true),
+    checkConnection: vi.fn().mockResolvedValue(true),
+    query: queryMock,
+    runTransaction: vi.fn(),
+  })),
+}));
+
+import { getStacks, getStackCount } from './db';
+
+describe('db.getStacks keyword filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockResolvedValue([]);
+  });
+
+  it('uses normalized image_keywords/keywords_dim in both stack-cache and non-stack branches', async () => {
+    await getStacks({ keyword: 'bird' });
+
+    // Skip stack_cache probe call from ensureStackCacheTable; pick the main getStacks SQL.
+    const mainCall = queryMock.mock.calls.find(([sql]) => !/SELECT 1 FROM stack_cache WHERE 1=0/.test(sql as string));
+    expect(mainCall).toBeDefined();
+    const [sql, params] = mainCall!;
+    expect(sql).not.toMatch(/\b(i|ci)\.keywords\s+LIKE/i);
+    expect(sql).toContain('JOIN image_keywords ik ON ik.image_id = ci.id');
+    expect(sql).toContain('WHERE ik.image_id = i.id');
+    expect(sql).toContain('LOWER(kd.keyword_display) LIKE LOWER(?)');
+    expect(sql).toContain('LOWER(kd.keyword_norm) LIKE LOWER(?)');
+
+    // Two for cache branch + two for non-stack branch.
+    const likeParams = (params as unknown[]).filter(p => p === '%bird%');
+    expect(likeParams.length).toBe(4);
+  });
+});
+
+describe('db.getStackCount keyword filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryMock.mockResolvedValue([{ count: 0 }]);
+  });
+
+  it('filters via normalized keyword tables and binds two LIKE params', async () => {
+    await getStackCount({ keyword: 'bird' });
+
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).not.toMatch(/\bi\.keywords\s+LIKE/i);
+    expect(sql).toContain('SELECT 1 FROM image_keywords ik');
+    expect(sql).toContain('JOIN keywords_dim kd ON ik.keyword_id = kd.keyword_id');
+    expect(sql).toContain('LOWER(kd.keyword_display) LIKE LOWER(?)');
+    expect(sql).toContain('LOWER(kd.keyword_norm) LIKE LOWER(?)');
+
+    expect(params).toEqual(expect.arrayContaining(['%bird%', '%bird%']));
+  });
+});

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1179,11 +1179,22 @@ export async function getStacks(options: StackQueryOptions = {}): Promise<unknow
 
     if (keyword) {
         // Filter stacks where at least one member image has this keyword
-        wherePartsCache.push('EXISTS (SELECT 1 FROM images ci WHERE ci.stack_id = sc.stack_id AND ci.keywords LIKE ?)');
-        topParams.push(`%${keyword}%`);
+        wherePartsCache.push(`EXISTS (
+            SELECT 1 FROM images ci
+            JOIN image_keywords ik ON ik.image_id = ci.id
+            JOIN keywords_dim kd ON ik.keyword_id = kd.keyword_id
+            WHERE ci.stack_id = sc.stack_id
+            AND (LOWER(kd.keyword_display) LIKE LOWER(?) OR LOWER(kd.keyword_norm) LIKE LOWER(?))
+        )`);
+        topParams.push(`%${keyword}%`, `%${keyword}%`);
 
-        wherePartsNonStack.push('i.keywords LIKE ?');
-        botParams.push(`%${keyword}%`);
+        wherePartsNonStack.push(`EXISTS (
+            SELECT 1 FROM image_keywords ik
+            JOIN keywords_dim kd ON ik.keyword_id = kd.keyword_id
+            WHERE ik.image_id = i.id
+            AND (LOWER(kd.keyword_display) LIKE LOWER(?) OR LOWER(kd.keyword_norm) LIKE LOWER(?))
+        )`);
+        botParams.push(`%${keyword}%`, `%${keyword}%`);
     }
 
     if (capturedDate) {
@@ -1381,8 +1392,13 @@ export async function getStackCount(options: StackQueryOptions = {}): Promise<nu
     }
 
     if (keyword) {
-        whereParts.push('i.keywords LIKE ?');
-        params.push(`%${keyword}%`);
+        whereParts.push(`EXISTS (
+            SELECT 1 FROM image_keywords ik
+            JOIN keywords_dim kd ON ik.keyword_id = kd.keyword_id
+            WHERE ik.image_id = i.id
+            AND (LOWER(kd.keyword_display) LIKE LOWER(?) OR LOWER(kd.keyword_norm) LIKE LOWER(?))
+        )`);
+        params.push(`%${keyword}%`, `%${keyword}%`);
     }
 
     if (capturedDate) {


### PR DESCRIPTION
## Summary

- `getStacks` (both stack-cache and non-stack branches) and `getStackCount` now filter by keyword via `EXISTS` against `image_keywords` + `keywords_dim`, replacing the legacy `i.keywords LIKE ?` reads.
- Matches the pattern already used by `getImagesByStack`/`getImages` (case-insensitive on both `keyword_display` and `keyword_norm`).
- Adds `electron/db.getStacks.test.ts` to lock the cutover for both functions.

This is the read-path prerequisite for backend Phase 4d (`image-scoring-backend#103`), which removes the `IMAGES.KEYWORDS` legacy column.

## Test plan

- [x] `npx vitest run electron/db.getStacks.test.ts electron/db.getImages.test.ts` — 5 passed
- [x] `npx vitest run` (full suite) — 205 passed
- [ ] Manual smoke: filter Stacks view by keyword in dev build

Closes #72