### PR TITLE
feat(gallery): pick/reject chips, stacks 1:1 skip, sync tombstones

### DIFF
--- a/electron/db.getDeletedImageKeys.test.ts
+++ b/electron/db.getDeletedImageKeys.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}));
+
+vi.mock('./config', () => ({
+  getConfigPath: vi.fn(() => '/tmp/config.json'),
+  loadAppConfig: vi.fn(() => ({
+    database: { engine: 'api', api: { url: 'http://127.0.0.1:7860' } },
+  })),
+}));
+
+vi.mock('./db/provider', () => ({
+  createDatabaseConnector: vi.fn(() => ({
+    connect: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    verifyStartup: vi.fn().mockResolvedValue(true),
+    checkConnection: vi.fn().mockResolvedValue(true),
+    query: queryMock,
+    runTransaction: vi.fn(),
+  })),
+}));
+
+import { getDeletedImageKeys } from './db';
+
+describe('db.getDeletedImageKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects from deleted_images', async () => {
+    queryMock.mockResolvedValue([]);
+    await getDeletedImageKeys();
+    const [sql] = queryMock.mock.calls[0];
+    expect(sql).toContain('SELECT image_uuid, file_name, original_path FROM deleted_images');
+  });
+
+  it('builds uuid+filename keys with a lowercased file name', async () => {
+    queryMock.mockResolvedValue([
+      { image_uuid: 'ABC-123', file_name: 'IMG_0001.NEF', original_path: null },
+    ]);
+
+    const { uuidNameKeys } = await getDeletedImageKeys();
+
+    expect(uuidNameKeys.has('ABC-123 img_0001.nef')).toBe(true);
+    expect(uuidNameKeys.size).toBe(1);
+  });
+
+  it('adds normalized and forward-slash variants of original_path', async () => {
+    // WSL-format path passes through normalizePathForDb unchanged on every platform.
+    queryMock.mockResolvedValue([
+      { image_uuid: null, file_name: null, original_path: '/mnt/d/Photos/IMG_0002.nef' },
+    ]);
+
+    const { originalPaths } = await getDeletedImageKeys();
+
+    expect(originalPaths.has('/mnt/d/Photos/IMG_0002.nef')).toBe(true);
+  });
+
+  it('skips rows without a usable image_uuid for the uuid+filename set', async () => {
+    queryMock.mockResolvedValue([
+      { image_uuid: '   ', file_name: 'IMG_0003.nef', original_path: null },
+      { image_uuid: null, file_name: 'IMG_0004.nef', original_path: null },
+    ]);
+
+    const { uuidNameKeys } = await getDeletedImageKeys();
+
+    expect(uuidNameKeys.size).toBe(0);
+  });
+
+  it('returns empty sets and warns when the deleted_images query fails', async () => {
+    queryMock.mockRejectedValueOnce(
+      Object.assign(new Error('relation "deleted_images" does not exist'), { code: '42P01' }),
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { uuidNameKeys, originalPaths } = await getDeletedImageKeys();
+
+    expect(uuidNameKeys.size).toBe(0);
+    expect(originalPaths.size).toBe(0);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/electron/db.getStacks.test.ts
+++ b/electron/db.getStacks.test.ts
@@ -48,6 +48,11 @@ describe('db.getStacks keyword filter', () => {
     expect(sql).toContain('WHERE ik.image_id = i.id');
     expect(sql).toContain('LOWER(kd.keyword_display) LIKE LOWER(?)');
     expect(sql).toContain('LOWER(kd.keyword_norm) LIKE LOWER(?)');
+    expect(sql).toContain('COUNT(*) FILTER (WHERE CASE');
+    expect(sql).toContain("ci.label = 'Red' THEN -1");
+    expect(sql).toContain("ci.label IN ('Green', 'Blue', 'Purple') THEN 1");
+    expect(sql).toContain('CASE WHEN CASE');
+    expect(sql).toContain("i.label IN ('Green', 'Blue', 'Purple') THEN 1");
 
     // Two for cache branch + two for non-stack branch.
     const likeParams = (params as unknown[]).filter(p => p === '%bird%');
@@ -100,6 +105,9 @@ describe('db.getSubstacksForStack', () => {
     expect(sql).toContain('FROM image_keywords ik');
     expect(sql).toContain('ss.id AS sub_stack_id');
     expect(sql).toContain('rep.file_path');
+    expect(sql).toContain('SUM(CASE WHEN pick_status = 1 THEN 1 ELSE 0 END)::bigint AS pick_count');
+    expect(sql).toContain('SUM(CASE WHEN pick_status = -1 THEN 1 ELSE 0 END)::bigint AS reject_count');
+    expect(sql).toContain('rep.pick_status');
 
     expect(params).toEqual([
       5,
@@ -166,6 +174,9 @@ describe('db.getSubstacksForStack', () => {
     expect(ungroupedSql).toContain('i.sub_stack_id IS NULL');
     expect(ungroupedSql).toContain("'Ungrouped' AS name");
     expect(ungroupedSql).toContain('TRUE AS is_ungrouped_sub_stack');
+    expect(ungroupedSql).toContain('oc.pick_count');
+    expect(ungroupedSql).toContain('oc.reject_count');
+    expect(ungroupedSql).toContain('rep.pick_status');
     expect(ungroupedParams).toEqual([5, 2, '%bird%', '%bird%', 5]);
   });
 
@@ -199,6 +210,7 @@ describe('db.getImagesBySubStack', () => {
     expect(sql).toContain('i.rating >= ?');
     expect(sql).toContain('i.label = ?');
     expect(sql).toContain('FROM image_keywords ik');
+    expect(sql).toContain('i.pick_status');
     expect(params).toEqual([
       12,
       2,
@@ -217,6 +229,22 @@ describe('db.getImagesBySubStack', () => {
     );
 
     await expect(getImagesBySubStack(12)).resolves.toEqual([]);
+  });
+
+  it('falls back when images.pick_status is not present', async () => {
+    queryMock
+      .mockRejectedValueOnce(Object.assign(new Error('column i.pick_status does not exist'), { code: '42703' }))
+      .mockResolvedValueOnce([]);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(getImagesBySubStack(12)).resolves.toEqual([]);
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    const [fallbackSql] = queryMock.mock.calls[1];
+    expect(fallbackSql).toContain("i.label = 'Red' THEN -1");
+    expect(fallbackSql).toContain("i.label IN ('Green', 'Blue', 'Purple') THEN 1");
+    expect(fallbackSql).toContain('END AS pick_status');
   });
 });
 
@@ -240,6 +268,7 @@ describe('db.getImagesByStackUngrouped', () => {
     expect(sql).toContain('i.rating >= ?');
     expect(sql).toContain('i.label = ?');
     expect(sql).toContain('FROM image_keywords ik');
+    expect(sql).toContain('i.pick_status');
     expect(params).toEqual([
       5,
       2,

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -899,6 +899,40 @@ export async function getDeletedImageMatchSets(): Promise<{
     return { originalIds, hashes };
 }
 
+/**
+ * Tombstone keys for the Sync skip check, preloaded once per run.
+ * Mirrors the matching `isImageDeleted` performs — (image_uuid AND file_name) OR
+ * original_path — but as in-memory sets to avoid a DB round-trip per candidate file.
+ */
+export async function getDeletedImageKeys(): Promise<{
+    uuidNameKeys: Set<string>;
+    originalPaths: Set<string>;
+}> {
+    const uuidNameKeys = new Set<string>();
+    const originalPaths = new Set<string>();
+    try {
+        const rows = await query<{
+            image_uuid: string | null;
+            file_name: string | null;
+            original_path: string | null;
+        }>('SELECT image_uuid, file_name, original_path FROM deleted_images');
+        for (const r of rows) {
+            const uuid = r.image_uuid?.trim();
+            if (uuid && r.file_name) {
+                uuidNameKeys.add(`${uuid} ${r.file_name.toLowerCase()}`);
+            }
+            const op = r.original_path;
+            if (op && op.trim()) {
+                originalPaths.add(normalizePathForDb(op));
+                originalPaths.add(op.replace(/\\/g, '/'));
+            }
+        }
+    } catch (e) {
+        console.warn('[DB] getDeletedImageKeys failed (ensure backend migration for deleted_images):', e);
+    }
+    return { uuidNameKeys, originalPaths };
+}
+
 export interface InsertImageRow {
     file_path: string;
     file_name: string;
@@ -1471,22 +1505,18 @@ export async function getStacks(options: StackQueryOptions = {}): Promise<unknow
     const whereClauseNonStack = 'WHERE ' + wherePartsNonStack.join(' AND ');
 
     const buildSql = (includePickStatus: boolean) => {
-        const stackPickStatsJoin = includePickStatus ? `
+        const stackPickStatusExpr = effectivePickStatusExpr(includePickStatus, 'ci');
+        const repPickStatusExpr = effectivePickStatusExpr(includePickStatus, 'i');
+        const stackPickStatsJoin = `
             LEFT JOIN LATERAL (
                 SELECT
-                    COUNT(*) FILTER (WHERE ci.pick_status = 1) AS pick_count,
-                    COUNT(*) FILTER (WHERE ci.pick_status = -1) AS reject_count
+                    COUNT(*) FILTER (WHERE ${stackPickStatusExpr} = 1) AS pick_count,
+                    COUNT(*) FILTER (WHERE ${stackPickStatusExpr} = -1) AS reject_count
                 FROM images ci
                 WHERE ci.stack_id = sc.stack_id
-            ) pick_stats ON TRUE` : '';
-        const stackPickCountExpr = includePickStatus ? 'pick_stats.pick_count' : 'CAST(0 AS BIGINT)';
-        const stackRejectCountExpr = includePickStatus ? 'pick_stats.reject_count' : 'CAST(0 AS BIGINT)';
-        const nonStackPickCountExpr = includePickStatus
-            ? 'CASE WHEN i.pick_status = 1 THEN 1 ELSE 0 END'
-            : '0';
-        const nonStackRejectCountExpr = includePickStatus
-            ? 'CASE WHEN i.pick_status = -1 THEN 1 ELSE 0 END'
-            : '0';
+            ) pick_stats ON TRUE`;
+        const nonStackPickCountExpr = `CASE WHEN ${repPickStatusExpr} = 1 THEN 1 ELSE 0 END`;
+        const nonStackRejectCountExpr = `CASE WHEN ${repPickStatusExpr} = -1 THEN 1 ELSE 0 END`;
 
         return `
         SELECT * FROM (
@@ -1496,8 +1526,8 @@ export async function getStacks(options: StackQueryOptions = {}): Promise<unknow
                 sc.image_count,
                 ${cacheSortCol} as sort_value,
                 sc.rep_image_id,
-                ${stackPickCountExpr} AS pick_count,
-                ${stackRejectCountExpr} AS reject_count,
+                pick_stats.pick_count AS pick_count,
+                pick_stats.reject_count AS reject_count,
                 ${imagePickStatusSelect(includePickStatus, 'i')},
                 i.id,
                 COALESCE(fp.path, i.file_path) as file_path,
@@ -1664,6 +1694,7 @@ export interface SubStackRow {
     score_paq2piq?: number;
     rating: number;
     label: string | null;
+    pick_status?: number | null;
     thumbnail_path?: string;
     name?: string | null;
     best_image_id?: number | null;
@@ -1672,6 +1703,8 @@ export interface SubStackRow {
     level2_semantic_space?: string | null;
     policy_version?: string | null;
     image_count?: number;
+    pick_count?: number;
+    reject_count?: number;
     created_at?: string;
     is_ungrouped_sub_stack?: boolean;
 }
@@ -1713,9 +1746,18 @@ function warnMissingPickStatusColumn(error: unknown): void {
 }
 
 function imagePickStatusSelect(includePickStatus: boolean, imageAlias = 'i'): string {
-    return includePickStatus
-        ? `${imageAlias}.pick_status`
-        : 'CAST(NULL AS INTEGER) AS pick_status';
+    return `${effectivePickStatusExpr(includePickStatus, imageAlias)} AS pick_status`;
+}
+
+function effectivePickStatusExpr(includePickStatus: boolean, imageAlias = 'i'): string {
+    const rawStatus = includePickStatus ? `${imageAlias}.pick_status` : 'NULL';
+    return `CASE
+        WHEN ${rawStatus} = 1 THEN 1
+        WHEN ${rawStatus} = -1 THEN -1
+        WHEN COALESCE(${rawStatus}, 0) = 0 AND ${imageAlias}.label = 'Red' THEN -1
+        WHEN COALESCE(${rawStatus}, 0) = 0 AND ${imageAlias}.label IN ('Green', 'Blue', 'Purple') THEN 1
+        ELSE COALESCE(${rawStatus}, 0)
+    END`;
 }
 
 async function queryWithOptionalPickStatus<T>(

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1854,6 +1854,10 @@ async function startFullApplication(): Promise<void> {
         const newFolderRelPaths = new Set<string>();
         const candidates: SyncCandidate[] = [];
 
+        // Preload deleted_images tombstones once so previously-deleted files are not
+        // re-imported by Sync (matches by image_uuid+file_name or original_path).
+        const deletedKeys = await db.getDeletedImageKeys();
+
         const processPhase = dryRun ? 'preview' : 'copying';
         let processedCount = 0;
         const concurrencyLimit = 15; // Safe parallelism for exiftool + DB queries
@@ -1953,6 +1957,19 @@ async function startFullApplication(): Promise<void> {
                     const year = dateStr.substring(0, 4);
                     const destDir = path.join(destRoot, camera, lens, year, dateStr);
                     const destFile = path.join(destDir, fileName);
+
+                    // Skip files previously deleted from the gallery (deleted_images tombstones)
+                    // so Sync does not resurrect them.
+                    const uuidNameKey = imageUuid ? `${imageUuid} ${fileName.toLowerCase()}` : null;
+                    const isTombstoned =
+                        (uuidNameKey !== null && deletedKeys.uuidNameKeys.has(uuidNameKey)) ||
+                        deletedKeys.originalPaths.has(db.normalizePathForDb(destFile)) ||
+                        deletedKeys.originalPaths.has(destFile.replace(/\\/g, '/'));
+                    if (isTombstoned) {
+                        console.warn(`[Sync] Skip (previously deleted): ${fileName}`);
+                        skippedCount++;
+                        return;
+                    }
 
                     if (await fs.promises.stat(destFile).then(() => true, () => false)) {
                         const existsByPath = await db.findImageByFilePath(destFile);

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -29,6 +29,7 @@ export interface ImageRow {
     score_liqe: number;
     rating: number;
     label: string | null;
+    pick_status?: number | null;
     created_at?: string;
     thumbnail_path?: string;
     stack_id?: number | null;
@@ -76,6 +77,8 @@ export interface StackRow extends ImageRow {
     stack_id?: number | null;
     stack_key?: number;
     image_count?: number;
+    pick_count?: number;
+    reject_count?: number;
     sort_value?: number;
 }
 
@@ -92,6 +95,8 @@ export interface SubStackRow extends ImageRow {
     level2_semantic_space?: string | null;
     policy_version?: string | null;
     image_count?: number;
+    pick_count?: number;
+    reject_count?: number;
     created_at?: string;
     is_ungrouped_sub_stack?: boolean;
 }

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -172,7 +172,7 @@ function AppContent() {
     handleSelectStack: handleSelectStackBase,
     handleSelectSubStack,
     handleImageDeleteFromStack,
-  } = useStacksMode(selectedFolderId, filters, refreshStacks, smartCoverEnabled);
+  } = useStacksMode(filters, refreshStacks, smartCoverEnabled);
 
   // Keep refs up to date for WebSocket callbacks
   stacksModeRef.current = stacksMode;

--- a/src/components/Gallery/GalleryGrid.module.css
+++ b/src/components/Gallery/GalleryGrid.module.css
@@ -127,9 +127,53 @@
 .cardScore {
   display: flex;
   justify-content: space-between;
+  align-items: center;
+  gap: 6px;
   font-size: 11px;
   color: var(--text-secondary);
   margin-top: 4px;
+  min-width: 0;
+}
+
+.cardScoreValue {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pickStatusGroup {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  flex: 0 1 auto;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.pickStatusChip {
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.pickStatusPick {
+  color: var(--color-success);
+  background: var(--color-success-bg);
+  border: 1px solid color-mix(in srgb, var(--color-success) 45%, transparent);
+}
+
+.pickStatusReject {
+  color: var(--color-danger);
+  background: var(--color-danger-bg);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 45%, transparent);
 }
 
 .filterEmptyState {

--- a/src/components/Gallery/GalleryGrid.test.tsx
+++ b/src/components/Gallery/GalleryGrid.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
 
 vi.mock('../../hooks/useKeyboardLayer', () => ({
     useKeyboardLayer: vi.fn(),
@@ -9,8 +10,19 @@ vi.mock('../../services/Logger', () => ({
     Logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+type VirtuosoGridMockProps = {
+    totalCount?: number;
+    itemContent?: (index: number) => ReactNode;
+};
+
 vi.mock('react-virtuoso', () => ({
-    VirtuosoGrid: () => <div data-testid="virtuoso-grid" />,
+    VirtuosoGrid: ({ totalCount = 0, itemContent }: VirtuosoGridMockProps) => (
+        <div data-testid="virtuoso-grid">
+            {Array.from({ length: totalCount }, (_, index) => (
+                <div key={index}>{itemContent?.(index)}</div>
+            ))}
+        </div>
+    ),
 }));
 
 import { GalleryGrid } from './GalleryGrid';
@@ -27,5 +39,56 @@ describe('GalleryGrid filter empty state', () => {
         render(<GalleryGrid images={[]} filterEmptyActive={false} />);
         expect(screen.queryByText('No images match filters')).toBeNull();
         expect(screen.getByTestId('virtuoso-grid')).toBeTruthy();
+    });
+});
+
+describe('GalleryGrid pick/reject status marks', () => {
+    const pickedImage = {
+        id: 1,
+        file_path: 'D:/photos/DSC_1651.NEF',
+        file_name: 'DSC_1651.NEF',
+        thumbnail_path: 'D:/photos/thumbs/DSC_1651.jpg',
+        score_general: 0.59,
+        rating: 5,
+        label: 'Blue',
+        pick_status: 0,
+    };
+
+    it('shows status marks inside an opened sub-stack', () => {
+        render(<GalleryGrid images={[pickedImage]} activeStackId={26888} activeSubStackId={11915} />);
+
+        expect(screen.getByText('Picked')).toBeTruthy();
+    });
+
+    it('does not show status marks in stack image view', () => {
+        render(<GalleryGrid images={[pickedImage]} activeStackId={26888} activeSubStackId={null} />);
+
+        expect(screen.queryByText('Picked')).toBeNull();
+    });
+
+    it('does not show aggregate status marks on stack or sub-stack cards', () => {
+        const stackCard = {
+            ...pickedImage,
+            image_count: 6,
+            pick_count: 6,
+            reject_count: 0,
+            name: 'substack_26888_1',
+            sub_stack_id: 11915,
+        };
+
+        const { rerender } = render(<GalleryGrid images={[]} stacks={[stackCard]} stacksMode />);
+        expect(screen.queryByText('Pick 6')).toBeNull();
+        expect(screen.queryByText('Picked')).toBeNull();
+
+        rerender(
+            <GalleryGrid
+                images={[stackCard]}
+                subStacksMode
+                activeStackId={26888}
+                activeSubStackId={null}
+            />
+        );
+        expect(screen.queryByText('Pick 6')).toBeNull();
+        expect(screen.queryByText('Picked')).toBeNull();
     });
 });

--- a/src/components/Gallery/GalleryGrid.tsx
+++ b/src/components/Gallery/GalleryGrid.tsx
@@ -21,6 +21,7 @@ interface Image {
     model_scores?: Record<string, number>;
     rating: number;
     label: string | null;
+    pick_status?: number | null;
     created_at?: string;
     title?: string;
     description?: string;
@@ -31,6 +32,8 @@ interface Image {
     sub_stack_key?: number;
     name?: string | null;
     image_count?: number;
+    pick_count?: number;
+    reject_count?: number;
     capture_date?: string;
     is_capture_date_fallback?: boolean;
     is_sub_stack_card?: boolean;
@@ -99,6 +102,25 @@ const ItemWrapper = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
         {children}
     </div>
 ));
+
+function numericStatusValue(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+
+function displayPickStatus(img: Image): number | null {
+    const explicit = numericStatusValue(img.pick_status);
+    if (explicit === 1 || explicit === -1) return explicit;
+
+    // Legacy libraries may only have the mirrored rating/label metadata populated.
+    if (img.label === 'Red') return -1;
+    if (img.label === 'Green' || img.label === 'Blue' || img.label === 'Purple') return 1;
+    return null;
+}
 
 export const GalleryGrid: React.FC<GalleryGridProps> = ({
     images, onSelect, onEndReached, subfolders, onSelectFolder,
@@ -204,7 +226,30 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                         label === 'Purple' ? 'var(--label-purple)' : 'transparent';
     }, []);
 
-    const renderImageCard = useCallback((img: Image, onClick: () => void) => {
+    const renderPickRejectStatus = useCallback((img: Image) => {
+        const chips: Array<{ key: string; text: string; className: string }> = [];
+
+        const status = displayPickStatus(img);
+        if (status === 1) {
+            chips.push({ key: 'pick', text: 'Picked', className: styles.pickStatusPick });
+        } else if (status === -1) {
+            chips.push({ key: 'reject', text: 'Rejected', className: styles.pickStatusReject });
+        }
+
+        if (chips.length === 0) return null;
+
+        return (
+            <span className={styles.pickStatusGroup} aria-label="Pick/reject status">
+                {chips.map((chip) => (
+                    <span key={chip.key} className={`${styles.pickStatusChip} ${chip.className}`}>
+                        {chip.text}
+                    </span>
+                ))}
+            </span>
+        );
+    }, []);
+
+    const renderImageCard = useCallback((img: Image, onClick: () => void, showPickRejectStatus = false) => {
         const labelColor = getLabelColor(img.label);
         return (
             <div
@@ -242,12 +287,13 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                         {img.file_name}
                     </div>
                     <div className={styles.cardScore}>
-                        <span>{getScoreDisplay(img)}</span>
+                        <span className={styles.cardScoreValue}>{getScoreDisplay(img)}</span>
+                        {showPickRejectStatus ? renderPickRejectStatus(img) : null}
                     </div>
                 </div>
             </div>
         );
-    }, [getScoreDisplay, getLabelColor, useGalleryThumbnail]);
+    }, [getScoreDisplay, getLabelColor, renderPickRejectStatus, useGalleryThumbnail]);
 
     const renderStackCard = useCallback((stack: Image, onClick: () => void, kind: 'stack' | 'substack' = 'stack') => {
         const labelColor = getLabelColor(stack.label);
@@ -307,7 +353,7 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                         {title}
                     </div>
                     <div className={styles.cardScore}>
-                        <span>{getScoreDisplay(stack)}</span>
+                        <span className={styles.cardScoreValue}>{getScoreDisplay(stack)}</span>
                     </div>
                 </div>
             </div>
@@ -339,9 +385,9 @@ export const GalleryGrid: React.FC<GalleryGridProps> = ({
                 }
             }, 'substack');
         } else {
-            return renderImageCard(item, () => onSelect && onSelect(item));
+            return renderImageCard(item, () => onSelect && onSelect(item), activeSubStackId !== null && activeSubStackId !== undefined);
         }
-    }, [displayData, isStacksView, isSubStacksView, renderStackCard, renderImageCard, onSelectStack, onSelectSubStack, onSelect]);
+    }, [activeStackId, activeSubStackId, displayData, isStacksView, isSubStacksView, renderStackCard, renderImageCard, onSelectStack, onSelectSubStack, onSelect]);
 
     const endReachedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const handleEndReached = useCallback(() => {

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -31,11 +31,14 @@ interface ImageRow {
     score_liqe: number;
     rating: number;
     label: string | null;
+    pick_status?: number | null;
     created_at?: string;
     thumbnail_path?: string;
     stack_id?: number | null;
     stack_key?: number;
     image_count?: number;
+    pick_count?: number;
+    reject_count?: number;
     sort_value?: number;
 }
 

--- a/src/hooks/useStacksMode.test.tsx
+++ b/src/hooks/useStacksMode.test.tsx
@@ -68,7 +68,7 @@ describe('useStacksMode sub-stack navigation', () => {
     electronApi.getSubstacksForStack.mockResolvedValue([subStack]);
     electronApi.getImagesByStack.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useStacksMode(undefined, filters, vi.fn(), false));
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
 
     act(() => {
       result.current.handleSelectStack(img(1, { stack_id: 7, image_count: 9 }), vi.fn());
@@ -88,7 +88,7 @@ describe('useStacksMode sub-stack navigation', () => {
     electronApi.getSubstacksForStack.mockResolvedValue([]);
     electronApi.getImagesByStack.mockResolvedValue([stackImage]);
 
-    const { result } = renderHook(() => useStacksMode(undefined, filters, vi.fn(), false));
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
 
     act(() => {
       result.current.handleSelectStack(img(2, { stack_id: 8, image_count: 1 }), vi.fn());
@@ -102,13 +102,34 @@ describe('useStacksMode sub-stack navigation', () => {
     expect(electronApi.getImagesByStack).toHaveBeenCalledWith(8, filters);
   });
 
+  it('skips the sub-stack layer when the only sub-stack maps one-to-one with the stack', async () => {
+    const subStack = img(251, { stack_id: 12, sub_stack_id: 120, image_count: 3 });
+    const stackImage = img(252, { stack_id: 12, sub_stack_id: 120 });
+    electronApi.getSubstacksForStack.mockResolvedValue([subStack]);
+    electronApi.getImagesByStack.mockResolvedValue([stackImage]);
+
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
+
+    act(() => {
+      result.current.handleSelectStack(img(6, { stack_id: 12, image_count: 3 }), vi.fn());
+    });
+
+    await waitFor(() => {
+      expect(result.current.activeStackDisplayImages).toEqual([stackImage]);
+    });
+
+    expect(result.current.hasSubStackCards).toBe(false);
+    expect(electronApi.getImagesByStack).toHaveBeenCalledWith(12, filters);
+    expect(electronApi.getImagesBySubStack).not.toHaveBeenCalled();
+  });
+
   it('loads sub-stack images after selecting a sub-stack card', async () => {
     const subStack = img(301, { stack_id: 9, sub_stack_id: 90, image_count: 2 });
     const subStackImage = img(302, { stack_id: 9, sub_stack_id: 90 });
     electronApi.getSubstacksForStack.mockResolvedValue([subStack]);
     electronApi.getImagesBySubStack.mockResolvedValue([subStackImage]);
 
-    const { result } = renderHook(() => useStacksMode(undefined, filters, vi.fn(), false));
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
 
     act(() => {
       result.current.handleSelectStack(img(3, { stack_id: 9, image_count: 4 }), vi.fn());
@@ -142,7 +163,7 @@ describe('useStacksMode sub-stack navigation', () => {
     electronApi.getSubstacksForStack.mockResolvedValue([subStack, ungrouped]);
     electronApi.getImagesByStackUngrouped.mockResolvedValue([ungroupedImage]);
 
-    const { result } = renderHook(() => useStacksMode(undefined, filters, vi.fn(), false));
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
 
     act(() => {
       result.current.handleSelectStack(img(4, { stack_id: 10, image_count: 3 }), vi.fn());
@@ -190,7 +211,7 @@ describe('useStacksMode sub-stack navigation', () => {
       .mockResolvedValueOnce([beforeRefresh])
       .mockResolvedValueOnce([afterRefresh]);
 
-    const { result } = renderHook(() => useStacksMode(undefined, filters, vi.fn(), false));
+    const { result } = renderHook(() => useStacksMode(filters, vi.fn(), false));
 
     act(() => {
       result.current.handleSelectStack(img(5, { stack_id: 11, image_count: 1 }), vi.fn());

--- a/src/hooks/useStacksMode.ts
+++ b/src/hooks/useStacksMode.ts
@@ -14,6 +14,7 @@ interface ImageRow {
   score_liqe?: number;
   rating: number;
   label: string | null;
+  pick_status?: number | null;
   created_at?: string;
   thumbnail_path?: string;
   stack_id?: number | null;
@@ -22,6 +23,8 @@ interface ImageRow {
   sub_stack_key?: number;
   name?: string | null;
   image_count?: number;
+  pick_count?: number;
+  reject_count?: number;
   sort_value?: number;
   is_ungrouped_sub_stack?: boolean;
 }
@@ -42,7 +45,6 @@ interface SubStackInfo {
  * loading stack images, and rebuilding the stack cache on first enable.
  */
 export function useStacksMode(
-  _selectedFolderId: number | undefined,
   filters: FilterState,
   refreshStacks: (opts?: { preserveItems?: boolean }) => void,
   smartCoverEnabled: boolean,
@@ -64,6 +66,7 @@ export function useStacksMode(
   const loadStackImages = useCallback(async (stackId: number) => {
     setStackImagesLoading(true);
     try {
+      // Stack drill-down intentionally shows the full root stack; stacks can span folders.
       const options = { ...filters };
       const imgs = await bridge.getImagesByStack(stackId, options);
       setStackImages(imgs);
@@ -107,16 +110,27 @@ export function useStacksMode(
   const loadUngroupedSubStackImagesRef = useRef(loadUngroupedSubStackImages);
   loadUngroupedSubStackImagesRef.current = loadUngroupedSubStackImages;
 
+  const isSingleSubStackEquivalentToStack = useCallback((subs: ImageRow[], stackId: number) => {
+    if (subs.length !== 1) return false;
+    const onlySubStack = subs[0];
+    if (onlySubStack.is_ungrouped_sub_stack || onlySubStack.sub_stack_id === null || onlySubStack.sub_stack_id === undefined) {
+      return false;
+    }
+    const knownStackCount = activeStackInfo?.stackId === stackId ? activeStackInfo.imageCount : 0;
+    return knownStackCount <= 0 || (onlySubStack.image_count || 0) === knownStackCount;
+  }, [activeStackInfo]);
+
   const loadStackLanding = useCallback(async (stackId: number) => {
     setSubStacksLoading(true);
     setSubStacks([]);
     setStackImages([]);
     try {
       const subs = await bridge.getSubstacksForStack(stackId, { ...filters });
-      setSubStacks(subs);
-      if (subs.length === 0) {
+      if (subs.length === 0 || isSingleSubStackEquivalentToStack(subs, stackId)) {
+        setSubStacks([]);
         await loadStackImages(stackId);
       } else {
+        setSubStacks(subs);
         setStackImages([]);
       }
     } catch (err) {
@@ -126,7 +140,7 @@ export function useStacksMode(
     } finally {
       setSubStacksLoading(false);
     }
-  }, [filters, loadStackImages]);
+  }, [filters, isSingleSubStackEquivalentToStack, loadStackImages]);
 
   const loadStackLandingRef = useRef(loadStackLanding);
   loadStackLandingRef.current = loadStackLanding;


### PR DESCRIPTION
## Summary
- Pick/reject chips in gallery grid
- Stacks 1:1 skip logic and deleted_images tombstone sync

Closes #124

## Test plan
- [x] npm run test:run (294 passed)
- [ ] CI green

Made with [Cursor](https://cursor.com)