### PR TITLE
feat(gallery): design package v1.2.0 embedding UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "electron-gallery",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-gallery",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "dependencies": {
-        "@synthet/image-scoring-design": "file:../image-scoring-ui",
+        "@synthet/image-scoring-design": "github:synthet/image-scoring-ui#v1.2.0",
         "@types/express": "^5.0.6",
         "electron-is-dev": "^3.0.1",
         "exiftool-vendored": "^35.11.0",
@@ -47,14 +47,6 @@
         "vite": "^7.2.4",
         "vitest": "^4.1.0",
         "wait-on": "^9.0.3"
-      }
-    },
-    "../image-scoring-ui": {
-      "name": "@synthet/image-scoring-design",
-      "version": "1.1.1",
-      "license": "MIT",
-      "devDependencies": {
-        "typescript": "^6.0.3"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -2268,8 +2260,12 @@
       "license": "MIT"
     },
     "node_modules/@synthet/image-scoring-design": {
-      "resolved": "../image-scoring-ui",
-      "link": true
+      "version": "1.2.0",
+      "resolved": "git+ssh://git@github.com/synthet/image-scoring-ui.git#7286113cc7d9910688a6a20ecac28d5eca1e6560",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18"
+      }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     ]
   },
   "dependencies": {
-    "@synthet/image-scoring-design": "github:synthet/image-scoring-ui#v1.0.0",
+    "@synthet/image-scoring-design": "github:synthet/image-scoring-ui#v1.2.0",
     "@types/express": "^5.0.6",
     "electron-is-dev": "^3.0.1",
     "exiftool-vendored": "^35.11.0",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -196,6 +196,10 @@ const FOLDER_API_STUB: Window['electron']['api'] = {
     getJobsQueue: async () => ({ queue_depth: 0, jobs: [] }),
     cancelJob: async () => ({ success: false, message: 'folder mode' }),
     getScopeTree: async () => ({ folders: [] }),
+    getScoringSortOptions: async () => [
+        { value: 'score_general', label: 'General', group: 'composite' as const },
+        { value: 'capture_date', label: 'Capture date', group: 'meta' as const },
+    ],
 };
 
 // ── HTTP Bridge (browser mode) ────────────────────────────────────────────────

--- a/src/components/Embeddings/EmbeddingMap.tsx
+++ b/src/components/Embeddings/EmbeddingMap.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { EmbeddingSpaceIcon, EMBEDDING_SPACE_LABELS } from '@synthet/image-scoring-design';
 
 export interface ProjectedEmbeddingPoint {
   id: number;
@@ -12,6 +13,7 @@ export interface ProjectedEmbeddingPoint {
 
 interface EmbeddingMapProps {
   points: ProjectedEmbeddingPoint[];
+  spaceCode?: string;
   isLoading?: boolean;
   error?: string | null;
   onRetry?: () => void;
@@ -26,6 +28,7 @@ interface EmbeddingMapProps {
  */
 export const EmbeddingMap: React.FC<EmbeddingMapProps> = ({
   points,
+  spaceCode,
   isLoading = false,
   error = null,
   onRetry,
@@ -72,6 +75,22 @@ export const EmbeddingMap: React.FC<EmbeddingMapProps> = ({
 
   return (
     <div style={{ padding: 20, height: '100%', overflow: 'auto' }}>
+      {spaceCode ? (
+        <div
+          style={{
+            marginBottom: 10,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+            color: '#aaa',
+          }}
+        >
+          <EmbeddingSpaceIcon code={spaceCode} size={16} />
+          <span title={spaceCode}>
+            {EMBEDDING_SPACE_LABELS[spaceCode] ?? spaceCode}
+          </span>
+        </div>
+      ) : null}
       <div style={{ marginBottom: 10, color: '#aaa' }}>
         Embedding map placeholder ({points.length} points)
       </div>

--- a/src/components/Search/SearchPage.module.css
+++ b/src/components/Search/SearchPage.module.css
@@ -306,6 +306,30 @@
 
 .metaSpace {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: #9d9d9d;
+}
+
+.metaSpaceLabel {
+  flex-shrink: 0;
+}
+
+.metaSpaceValue {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: #cccccc;
+}
+
+.metaSpaceValue span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 14rem;
 }
 
 .filterChips {

--- a/src/components/Search/SearchPage.tsx
+++ b/src/components/Search/SearchPage.tsx
@@ -7,6 +7,7 @@ import {
     X,
     Loader2,
 } from 'lucide-react';
+import { EmbeddingSpaceIcon, EMBEDDING_SPACE_LABELS } from '@synthet/image-scoring-design';
 import type { TextSearchResultItem } from '../../../electron/apiTypes';
 import type { Folder } from '../Tree/treeUtils';
 import { bridge } from '../../bridge';
@@ -504,10 +505,19 @@ export function SearchPage({
                                 />
                             </div>
                             <div className={styles.metaSpace}>
-                                space:{' '}
-                                <span style={{ fontFamily: 'ui-monospace, monospace' }}>
-                                    {data?.embedding_space}
-                                </span>
+                                <span className={styles.metaSpaceLabel}>space:</span>
+                                {data?.embedding_space ? (
+                                    <span className={styles.metaSpaceValue}>
+                                        <EmbeddingSpaceIcon
+                                            code={data.embedding_space}
+                                            size={14}
+                                        />
+                                        <span title={data.embedding_space}>
+                                            {EMBEDDING_SPACE_LABELS[data.embedding_space] ??
+                                                data.embedding_space}
+                                        </span>
+                                    </span>
+                                ) : null}
                             </div>
                         </div>
                         <div className={styles.grid}>

--- a/src/components/Viewer/ImageViewer.test.tsx
+++ b/src/components/Viewer/ImageViewer.test.tsx
@@ -5,6 +5,10 @@ vi.mock('../../hooks/useKeyboardLayer', () => ({
     useKeyboardLayer: vi.fn(),
 }));
 
+vi.mock('../../utils/exportImageBake', () => ({
+    bakeExifOrientationToBlob: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock('../../hooks/useDatabase', async (importOriginal) => {
     const mod = await importOriginal<typeof import('../../hooks/useDatabase')>();
     return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,9 @@ console.log(`[Vite] Proxying /gallery-api and /media to: ${galleryServerUrl}`)
 // https://vite.dev/config/
 export default defineConfig(({ command }) => ({
   plugins: [galleryBrowserProxy(galleryServerUrl), react()],
+  resolve: {
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
+  },
   // Dev: `/` avoids baseMiddleware 404 for absolute paths (e.g. /gallery-api/ping) that
   // would otherwise fall through if proxy order fails. Build keeps `./` for Electron/file://.
   base: command === 'serve' ? '/' : './',


### PR DESCRIPTION
## Summary
- Bump @synthet/image-scoring-design to github:synthet/image-scoring-ui#v1.2.0
- Embedding map and search page UI updates

## Test plan
- [x] npx tsc --noEmit
- [ ] CI green

Made with [Cursor](https://cursor.com)