### PR TITLE
fix(menu): reveal-in-explorer prefers selected folder over viewer image

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -632,7 +632,7 @@ const rebuildApplicationMenu = () => {
                     label: 'Reveal in Explorer',
                     enabled: !!currentSelectionPath || !!currentExportImageContext?.sourcePath,
                     click: () => {
-                        const pathToReveal = currentExportImageContext?.sourcePath || currentSelectionPath;
+                        const pathToReveal = currentSelectionPath || currentExportImageContext?.sourcePath;
                         if (pathToReveal) {
                             shell.showItemInFolder(pathToReveal);
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-gallery",
-  "version": "7.14.0",
+  "version": "7.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-gallery",
-      "version": "7.14.0",
+      "version": "7.17.0",
       "dependencies": {
         "@synthet/image-scoring-design": "github:synthet/image-scoring-ui#v1.2.0",
         "@types/express": "^5.0.6",


### PR DESCRIPTION
When both a sidebar folder and a viewer image are active, the click
handler was evaluating `currentExportImageContext?.sourcePath` first,
so Explorer opened at the image instead of the selected folder.
Reverses the operand order to match the `enabled` condition, which
already gives priority to `currentSelectionPath`.

Closes #117

https://claude.ai/code/session_011pVHVeDo8nXG3JoBGqCgym