### PR TITLE
fix(sync): don't strand on-disk-but-unindexed files below the date threshold

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2042,8 +2042,16 @@ async function startFullApplication(): Promise<void> {
                             const year = dateStr.substring(0, 4);
                             const destFileEarly = path.join(destRoot, camera, lens, year, dateStr, fileName);
                             if (await fs.promises.stat(destFileEarly).then(() => true, () => false)) {
-                                skippedCount++;
-                                return;
+                                // The dest file exists on disk, but only treat it as "already
+                                // synced" if it is actually indexed. A prior run may have copied
+                                // the file and then failed before importing it; in that case we
+                                // must fall through to the normal path so it gets imported rather
+                                // than skipped forever by this below-threshold fast path.
+                                const existsByPath = await db.findImageByFilePath(destFileEarly);
+                                if (existsByPath) {
+                                    skippedCount++;
+                                    return;
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Problem

The Sync below-threshold quick-skip treated "destination file exists on disk" as "already synced" and skipped the file **without checking the database**. Files that a prior run copied but failed to import (interrupted import phase) became permanently invisible to Sync — every later run short-circuited them via the threshold fast path.

Observed on a real library: **684 NEF** files (2026-06-06: 269, 2026-06-07: 415) sat on disk under `D:\Photos` but were missing from the gallery DB. A sync run imported only the two dates above the threshold (6/8, 6/14).

## Fix

In the quick-skip branch of `runSyncFromSource` (`electron/main.ts`), check `db.findImageByFilePath` before skipping. Only skip when the file is actually indexed; otherwise fall through to the normal path, which already imports on-disk-but-unindexed files. This preserves the fast-skip optimization for genuinely-synced files while closing the data gap.

## Verification

- `npx tsc --noEmit` clean.
- The 684 stranded files were re-imported (DB now matches disk: 6/6 → 295, 6/7 → 415) and queued for scoring (jobs 4154, 4155).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)