### PR TITLE
docs: structure wiki as OKF bundle

### DIFF
--- a/docs/CANONICAL_SOURCES.md
+++ b/docs/CANONICAL_SOURCES.md
@@ -1,3 +1,12 @@
+---
+type: "Documentation"
+title: "Canonical Sources"
+description: "Use this map before changing integration contracts, renderer labels, database access, IPC boundaries, or RAW/export behavior."
+resource: "docs/CANONICAL_SOURCES.md"
+tags: ["gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Canonical Sources
 
 Use this map before changing integration contracts, renderer labels, database access, IPC boundaries, or RAW/export behavior.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,3 +1,12 @@
+---
+type: "Guide"
+title: "Development"
+description: "Run commands from the gallery repo root."
+resource: "docs/DEVELOPMENT.md"
+tags: ["gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Development
 
 Run commands from the gallery repo root.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,29 @@
+---
+type: "Index"
+title: "Driftara Gallery Documentation"
+description: "This is the documentation hub for image-scoring-gallery, the Electron + React + TypeScript desktop app for browsing Vexlum Scoring libraries."
+resource: "docs/README.md"
+tags: ["gallery-docs", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Driftara Gallery Documentation
 
 This is the documentation hub for **image-scoring-gallery**, the Electron + React + TypeScript desktop app for browsing Vexlum Scoring libraries.
 
 The backend owns REST API contracts, database schema, and pipeline phase terminology. The gallery owns Electron architecture, IPC/preload boundaries, renderer behavior, API-client usage, and desktop workflows.
+
+## OKF Bundle Shape
+
+`docs/` is organized as an Open Knowledge Format (OKF)-style bundle:
+
+- Every Markdown file is a concept with YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`).
+- The repository-relative path in `resource` is the concept identity.
+- Section `README.md` and `INDEX.md` files are navigation indexes for progressive disclosure.
+- Relative Markdown links encode relationships between concepts.
+- [log.md](log.md) is the chronological history for documentation maintenance.
+
+See [WIKI_SCHEMA.md](WIKI_SCHEMA.md) for the canonical field rules and maintenance workflow.
 
 ## Backend Authority
 

--- a/docs/WIKI_SCHEMA.md
+++ b/docs/WIKI_SCHEMA.md
@@ -1,6 +1,45 @@
+---
+type: "Documentation"
+title: "Wiki schema — image-scoring-gallery docs/"
+description: "This repo keeps docs/ as a small wiki aligned with image-scoring-backend habits: indexed sections, relative links, and an activity log."
+resource: "docs/WIKI_SCHEMA.md"
+tags: ["gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Wiki schema — image-scoring-gallery `docs/`
 
 This repo keeps `docs/` as a small wiki aligned with **image-scoring-backend** habits: indexed sections, relative links, and an activity log.
+
+The docs tree is also structured as an **Open Knowledge Format (OKF)-style bundle**: every Markdown page is a concept file with lightweight YAML frontmatter, the file path is the stable concept identity, section `README.md`/`INDEX.md` pages provide progressive-disclosure navigation, normal Markdown links express relationships, and `log.md` records chronological change history.
+
+## OKF concept frontmatter
+
+Every `docs/**/*.md` file starts with YAML frontmatter containing the repo's OKF interoperability surface:
+
+| Field | Required | Purpose |
+|-------|----------|---------|
+| `type` | Yes | Concept class, such as `Index`, `Guide`, `Architecture`, `Implemented Feature`, `Planned Feature`, `Report`, `Technical Reference`, `Backlog`, or `Log`. |
+| `title` | Yes | Human-readable page title, usually matching the first H1. |
+| `description` | Yes | Short summary that agents and search tools can show without reading the full page. |
+| `resource` | Yes | Repository-relative path to the Markdown file; this mirrors the file-path concept identity. |
+| `tags` | Yes | Small list of queryable tags. Include `gallery-docs` plus folder/topic tags. |
+| `timestamp` | Yes | Last documentation-structure or content refresh timestamp in UTC ISO-8601 form. |
+
+Example:
+
+```yaml
+---
+type: "Guide"
+title: "Testing and Coverage"
+description: "Vitest and coverage notes for renderer and Electron-facing tests."
+resource: "docs/guides/03-testing-and-coverage.md"
+tags: ["gallery-docs", "guides"]
+timestamp: 2026-06-16T00:00:00Z
+---
+```
+
+When a page moves, update `resource` and all relative links in the same change. When a page's meaning changes materially, refresh `description`, `tags`, and `timestamp`.
 
 ## Page types and folders
 

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -1,3 +1,12 @@
+---
+type: "Architecture"
+title: "System Overview"
+description: "Driftara Gallery is an Electron + React + TypeScript + Vite desktop app for browsing libraries produced by Vexlum Scoring."
+resource: "docs/architecture/01-system-overview.md"
+tags: ["architecture", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # System Overview
 
 Driftara Gallery is an **Electron + React + TypeScript + Vite** desktop app for browsing libraries produced by **Vexlum Scoring**.

--- a/docs/architecture/02-database-design.md
+++ b/docs/architecture/02-database-design.md
@@ -1,3 +1,12 @@
+---
+type: "Architecture"
+title: "Database Design"
+description: "PostgreSQL + pgvector is the primary database architecture. The backend owns schema and migrations; the gallery consumes that schema from the Electron main process."
+resource: "docs/architecture/02-database-design.md"
+tags: ["architecture", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Database Design
 
 PostgreSQL + pgvector is the primary database architecture. The backend owns schema and migrations; the gallery consumes that schema from the Electron main process.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Architecture"
+description: "Core system design and high-level technical overviews."
+resource: "docs/architecture/README.md"
+tags: ["architecture", "gallery-docs", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Architecture
 
 Core system design and high-level technical overviews.

--- a/docs/architecture/backup-feature.md
+++ b/docs/architecture/backup-feature.md
@@ -1,3 +1,12 @@
+---
+type: "Architecture"
+title: "Backup feature specification (Gallery)"
+description: "Canonical specification for the Backup feature in image-scoring-gallery (Electron main process, DB layer, preload, BackupModal). File references are repo-relative."
+resource: "docs/architecture/backup-feature.md"
+tags: ["architecture", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Backup feature specification (Gallery)
 
 Canonical specification for the **Backup** feature in **image-scoring-gallery** (Electron main process, DB layer, preload, `BackupModal`). File references are repo-relative.

--- a/docs/architecture/import-discovery-alignment.md
+++ b/docs/architecture/import-discovery-alignment.md
@@ -1,3 +1,12 @@
+---
+type: "Architecture"
+title: "Import vs pipeline Discovery — alignment plan"
+description: "Canonical plan (problem statement, options, phased work, testing):"
+resource: "docs/architecture/import-discovery-alignment.md"
+tags: ["architecture", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Import vs pipeline Discovery — alignment plan
 
 Canonical plan (problem statement, options, phased work, testing):  

--- a/docs/design/DESIGN_SYSTEM.md
+++ b/docs/design/DESIGN_SYSTEM.md
@@ -1,3 +1,12 @@
+---
+type: "Design Reference"
+title: "Design system — gallery pointer"
+description: "Canonical doc: image-scoring-ui docs/DESIGNSYSTEM.md (sibling clone: ../image-scoring-ui/docs/DESIGNSYSTEM.md)."
+resource: "docs/design/DESIGN_SYSTEM.md"
+tags: ["design", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Design system — gallery pointer
 
 **Canonical doc:** [image-scoring-ui `docs/DESIGN_SYSTEM.md`](https://github.com/synthet/image-scoring-ui/blob/main/docs/DESIGN_SYSTEM.md) (sibling clone: [`../image-scoring-ui/docs/DESIGN_SYSTEM.md`](../../image-scoring-ui/docs/DESIGN_SYSTEM.md)).

--- a/docs/design/FRONTEND_UX_SPEC.md
+++ b/docs/design/FRONTEND_UX_SPEC.md
@@ -1,3 +1,12 @@
+---
+type: "Design Reference"
+title: "UX/UI Design Visual Specification"
+description: "This document outlines the visual design, user experience, and UI specifications for the Driftara Gallery (image-scoring-gallery) frontend application."
+resource: "docs/design/FRONTEND_UX_SPEC.md"
+tags: ["design", "gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # UX/UI Design Visual Specification
 
 This document outlines the visual design, user experience, and UI specifications for the **Driftara Gallery** (`image-scoring-gallery`) frontend application.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Features"
+description: "Documentation for implemented and planned features."
+resource: "docs/features/README.md"
+tags: ["features", "gallery-docs", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Features
 
 Documentation for implemented and planned features.

--- a/docs/features/implemented/01-nef-raw-fallback.md
+++ b/docs/features/implemented/01-nef-raw-fallback.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "NEF/RAW preview fallback"
+description: "Purpose: Show Nikon NEF and other RAW files in the desktop viewer when a normal bitmap path is unavailable, using a tiered strategy (embedded preview, LibRaw/exiftool paths, then b"
+resource: "docs/features/implemented/01-nef-raw-fallback.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # NEF/RAW preview fallback
 
 **Purpose:** Show **Nikon NEF** and other RAW files in the desktop viewer when a normal bitmap path is unavailable, using a tiered strategy (embedded preview, LibRaw/exiftool paths, then backend JPEG).

--- a/docs/features/implemented/02-desktop-shell-and-navigation.md
+++ b/docs/features/implemented/02-desktop-shell-and-navigation.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "Desktop shell and navigation"
+description: "Purpose: Run the gallery as an Electron desktop app with a Vite renderer: window lifecycle, menus, optional WebUI-only shell mode, and navigation across gallery grid, viewer, impor"
+resource: "docs/features/implemented/02-desktop-shell-and-navigation.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Desktop shell and navigation
 
 **Purpose:** Run the gallery as an **Electron** desktop app with a **Vite** renderer: window lifecycle, menus, optional **WebUI-only** shell mode, and navigation across gallery grid, viewer, import, semantic search, and settings.

--- a/docs/features/implemented/03-database-engine-modes.md
+++ b/docs/features/implemented/03-database-engine-modes.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "Database engine modes"
+description: "Purpose: Query and update library metadata either directly against PostgreSQL (database.engine: \"pg\") or via the backend’s SQL-over-HTTP bridge (database.engine: \"api\"), using one "
+resource: "docs/features/implemented/03-database-engine-modes.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Database engine modes
 
 **Purpose:** Query and update library metadata either **directly against PostgreSQL** (`database.engine: "pg"`) or via the backend’s **SQL-over-HTTP** bridge (`database.engine: "api"`), using one abstraction in the renderer.

--- a/docs/features/implemented/04-backend-api-jobs.md
+++ b/docs/features/implemented/04-backend-api-jobs.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "Backend API and jobs (Electron integration)"
+description: "Purpose: Start and monitor scoring, tagging, clustering, and pipeline work on the Python WebUI from the Electron main process, and surface job queue / recent jobs / scope tree data"
+resource: "docs/features/implemented/04-backend-api-jobs.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Backend API and jobs (Electron integration)
 
 **Purpose:** Start and monitor **scoring**, **tagging**, **clustering**, and **pipeline** work on the Python WebUI from the Electron main process, and surface **job queue** / **recent jobs** / **scope tree** data in the UI.

--- a/docs/features/implemented/05-jpeg-export-exif-orientation.md
+++ b/docs/features/implemented/05-jpeg-export-exif-orientation.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "JPEG export and EXIF orientation"
+description: "Purpose: Document why File → Export must produce a JPEG whose pixels match the on-screen preview and whose EXIF Orientation is 1 (or absent), so system viewers (e.g. Windows Photos"
+resource: "docs/features/implemented/05-jpeg-export-exif-orientation.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # JPEG export and EXIF orientation
 
 **Purpose:** Document why **File → Export** must produce a JPEG whose **pixels** match the on-screen preview and whose **EXIF Orientation is 1** (or absent), so system viewers (e.g. Windows Photos) do not apply a second rotation.

--- a/docs/features/implemented/06-culling-stack-analytics.md
+++ b/docs/features/implemented/06-culling-stack-analytics.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "Culling stack analytics (Driftara Gallery)"
+description: "Status: Implemented (MVP)"
+resource: "docs/features/implemented/06-culling-stack-analytics.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Culling stack analytics (Driftara Gallery)
 
 **Status:** Implemented (MVP)  

--- a/docs/features/implemented/06-sync-from-device-workflow.md
+++ b/docs/features/implemented/06-sync-from-device-workflow.md
@@ -1,3 +1,12 @@
+---
+type: "Implemented Feature"
+title: "Sync from device (Electron workflow)"
+description: "End-to-end behavior of File → Sync in Driftara Gallery: filesystem scan, optional copy into the configured photo tree, direct PostgreSQL registration, and backend pipeline submissi"
+resource: "docs/features/implemented/06-sync-from-device-workflow.md"
+tags: ["features", "gallery-docs", "implemented"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Sync from device (Electron workflow)
 
 End-to-end behavior of **File → Sync** in Driftara Gallery: filesystem scan, optional copy into the configured photo tree, direct PostgreSQL registration, and backend pipeline submission. Use this page when debugging progress UI, IPC, or “why counts don’t match.”

--- a/docs/features/implemented/INDEX.md
+++ b/docs/features/implemented/INDEX.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Features Implemented"
+description: "Catalog of shipped desktop behavior. Backend API/schema/pipeline contracts remain owned by image-scoring-backend; link to backend authority instead of restating fields or phase def"
+resource: "docs/features/implemented/INDEX.md"
+tags: ["features", "gallery-docs", "implemented", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Features Implemented
 
 Catalog of shipped desktop behavior. Backend API/schema/pipeline contracts remain owned by **image-scoring-backend**; link to backend authority instead of restating fields or phase definitions.

--- a/docs/features/implemented/README.md
+++ b/docs/features/implemented/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Implemented Features"
+description: "Documentation for features that are currently implemented and in use."
+resource: "docs/features/implemented/README.md"
+tags: ["features", "gallery-docs", "implemented", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Implemented Features
 
 Documentation for features that are currently implemented and in use.

--- a/docs/features/planned/01-windows-native-viewer.md
+++ b/docs/features/planned/01-windows-native-viewer.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "Windows Native Image Gallery Viewer - Implementation Plan"
+description: "A native Windows application (C++/Win32) that provides fast, native file browsing for images stored in the scoringhistory.db database. The app mimics the Python Gallery feature but"
+resource: "docs/features/planned/01-windows-native-viewer.md"
+tags: ["features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Windows Native Image Gallery Viewer - Implementation Plan
 
 ## Overview

--- a/docs/features/planned/README.md
+++ b/docs/features/planned/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Planned Features"
+description: "Documentation for features not yet implemented."
+resource: "docs/features/planned/README.md"
+tags: ["features", "gallery-docs", "index", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Planned Features
 
 Documentation for features not yet implemented.

--- a/docs/features/planned/embeddings/00-summary.md
+++ b/docs/features/planned/embeddings/00-summary.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "Integrating image_embedding Features into Electron App"
+description: "Based on the backend embedding applications plan for leveraging MobileNetV2 1280-d feature vectors, this document summarizes how the image-scoring-gallery frontend will expose thes"
+resource: "docs/features/planned/embeddings/00-summary.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Integrating `image_embedding` Features into Electron App
 
 Based on the [backend embedding applications](https://github.com/synthet/image-scoring-backend/blob/main/docs/features/planned/embeddings/EMBEDDING_APPLICATIONS.md) plan for leveraging MobileNetV2 1280-d feature vectors, this document summarizes how the `image-scoring-gallery` frontend will expose these capabilities.

--- a/docs/features/planned/embeddings/01-diversity-selection.md
+++ b/docs/features/planned/embeddings/01-diversity-selection.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "01 - Diversity-Aware Selection (Frontend)"
+description: "Status: Implemented"
+resource: "docs/features/planned/embeddings/01-diversity-selection.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 01 - Diversity-Aware Selection (Frontend)
 
 *Status: **Implemented***

--- a/docs/features/planned/embeddings/02-near-duplicate-detection.md
+++ b/docs/features/planned/embeddings/02-near-duplicate-detection.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "02 - Near-Duplicate Detection (Frontend)"
+description: "Status: Implemented"
+resource: "docs/features/planned/embeddings/02-near-duplicate-detection.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 02 - Near-Duplicate Detection (Frontend)
 
 *Status: **Implemented***

--- a/docs/features/planned/embeddings/03-tag-propagation.md
+++ b/docs/features/planned/embeddings/03-tag-propagation.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "03 - Tag Propagation (Frontend)"
+description: "Status: Planned"
+resource: "docs/features/planned/embeddings/03-tag-propagation.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 03 - Tag Propagation (Frontend)
 
 *Status: **Planned***

--- a/docs/features/planned/embeddings/04-outlier-detection.md
+++ b/docs/features/planned/embeddings/04-outlier-detection.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "04 - Outlier Detection (Frontend)"
+description: "Status: Planned"
+resource: "docs/features/planned/embeddings/04-outlier-detection.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 04 - Outlier Detection (Frontend)
 
 *Status: **Planned***

--- a/docs/features/planned/embeddings/05-2d-embedding-map.md
+++ b/docs/features/planned/embeddings/05-2d-embedding-map.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "05 - 2D Embedding Map (Frontend)"
+description: "Status: In Progress (Scaffolded on March 28, 2026)"
+resource: "docs/features/planned/embeddings/05-2d-embedding-map.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 05 - 2D Embedding Map (Frontend)
 
 *Status: **In Progress (Scaffolded on March 28, 2026)***

--- a/docs/features/planned/embeddings/06-smart-stack-representative.md
+++ b/docs/features/planned/embeddings/06-smart-stack-representative.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "06 - Smart Stack Representative (Frontend)"
+description: "Status: In Progress (Preference + request threading scaffolded on March 28, 2026)"
+resource: "docs/features/planned/embeddings/06-smart-stack-representative.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 06 - Smart Stack Representative (Frontend)
 
 *Status: **In Progress (Preference + request threading scaffolded on March 28, 2026)***

--- a/docs/features/planned/embeddings/07-more-like-this-ui.md
+++ b/docs/features/planned/embeddings/07-more-like-this-ui.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "07 - More Like This UI (Frontend)"
+description: "Status: Implemented"
+resource: "docs/features/planned/embeddings/07-more-like-this-ui.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 07 - More Like This UI (Frontend)
 
 *Status: **Implemented***

--- a/docs/features/planned/embeddings/08-gradio-integration.md
+++ b/docs/features/planned/embeddings/08-gradio-integration.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "08 - Python Pipeline Integration (Gradio & Headless)"
+description: "Status: In Progress"
+resource: "docs/features/planned/embeddings/08-gradio-integration.md"
+tags: ["embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # 08 - Python Pipeline Integration (Gradio & Headless)
 
 *Status: **In Progress***

--- a/docs/features/planned/embeddings/README.md
+++ b/docs/features/planned/embeddings/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Embedding Applications — gallery hub"
+description: "Source of truth (algorithms, API, DB): image-scoring-backend docs/features/planned/embeddings/ — start with EMBEDDINGAPPLICATIONS.md and EMBEDDINGAPPLICATIONSINDEX.md. Do not dupli"
+resource: "docs/features/planned/embeddings/README.md"
+tags: ["embeddings", "features", "gallery-docs", "index", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Embedding Applications — gallery hub
 
 **Source of truth (algorithms, API, DB):** **[image-scoring-backend `docs/features/planned/embeddings/`](https://github.com/synthet/image-scoring-backend/tree/main/docs/plans/embedding)** — start with [`EMBEDDING_APPLICATIONS.md`](https://github.com/synthet/image-scoring-backend/blob/main/docs/features/planned/embeddings/EMBEDDING_APPLICATIONS.md) and [`EMBEDDING_APPLICATIONS_INDEX.md`](https://github.com/synthet/image-scoring-backend/blob/main/docs/features/planned/embeddings/EMBEDDING_APPLICATIONS_INDEX.md). Do not duplicate long backend prose here.

--- a/docs/features/planned/embeddings/TODO.md
+++ b/docs/features/planned/embeddings/TODO.md
@@ -1,3 +1,12 @@
+---
+type: "Backlog"
+title: "Embedding Features TODO (retired)"
+description: "The canonical task queue is the GitHub Project board (filter by area:embeddings):"
+resource: "docs/features/planned/embeddings/TODO.md"
+tags: ["backlog", "embeddings", "features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Embedding Features TODO (retired)
 
 The canonical task queue is the **GitHub Project board** (filter by `area:embeddings`):

--- a/docs/features/planned/species-conflict-resolution.md
+++ b/docs/features/planned/species-conflict-resolution.md
@@ -1,3 +1,12 @@
+---
+type: "Planned Feature"
+title: "Single Bird Species per Image (BioCLIP top‑1)"
+description: "Status: Planned (proposal)"
+resource: "docs/features/planned/species-conflict-resolution.md"
+tags: ["features", "gallery-docs", "planned"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Single Bird Species per Image (BioCLIP top‑1)
 
 *Status: **Planned (proposal)***

--- a/docs/guides/01-lint-recommendations.md
+++ b/docs/guides/01-lint-recommendations.md
@@ -1,3 +1,12 @@
+---
+type: "Guide"
+title: "Lint Recommendations"
+description: "Quick reference for ESLint fixes. For the full audit with detailed findings by file, see ESLint Audit (Mar 2026)."
+resource: "docs/guides/01-lint-recommendations.md"
+tags: ["gallery-docs", "guides"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Lint Recommendations
 
 Quick reference for ESLint fixes. For the full audit with detailed findings by file, see [ESLint Audit (Mar 2026)](../reports/03-eslint-audit-2026-03.md).

--- a/docs/guides/02-api-backend-config.md
+++ b/docs/guides/02-api-backend-config.md
@@ -1,3 +1,12 @@
+---
+type: "Guide"
+title: "API Backend Configuration"
+description: "This gallery can discover the Python backend automatically, but you can also pin or redirect it with config.json."
+resource: "docs/guides/02-api-backend-config.md"
+tags: ["gallery-docs", "guides"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # API Backend Configuration
 
 This gallery can discover the Python backend automatically, but you can also pin or redirect it with `config.json`.

--- a/docs/guides/03-testing-and-coverage.md
+++ b/docs/guides/03-testing-and-coverage.md
@@ -1,3 +1,12 @@
+---
+type: "Guide"
+title: "Testing and Coverage Guide"
+description: "This project uses Vitest for unit/integration tests and V8 coverage reporting."
+resource: "docs/guides/03-testing-and-coverage.md"
+tags: ["gallery-docs", "guides"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Testing and Coverage Guide
 
 This project uses Vitest for unit/integration tests and V8 coverage reporting.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Guides"
+description: "Development workflows and maintenance recommendations."
+resource: "docs/guides/README.md"
+tags: ["gallery-docs", "guides", "index"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Guides
 
 Development workflows and maintenance recommendations.

--- a/docs/integration/TODO.md
+++ b/docs/integration/TODO.md
@@ -1,3 +1,12 @@
+---
+type: "Backlog"
+title: "Integration TODO"
+description: "This backlog separates backend-owned contract work from gallery implementation work. The canonical project/task queue may still live outside this file; use this page as an integrat"
+resource: "docs/integration/TODO.md"
+tags: ["backlog", "gallery-docs", "integration"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Integration TODO
 
 This backlog separates backend-owned contract work from gallery implementation work. The canonical project/task queue may still live outside this file; use this page as an integration handoff map.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,9 +1,19 @@
+---
+type: "Log"
+title: "Documentation Activity Log"
+description: "Chronological record of wiki maintenance activities. Newest entries first."
+resource: "docs/log.md"
+tags: ["gallery-docs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Documentation Activity Log
 
 Chronological record of wiki maintenance activities. Newest entries first.
 
 ## 2026-06
 
+- 2026-06-16: reorganized — `docs/` as an Open Knowledge Format-style bundle: added YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) to every Markdown concept page; documented OKF field rules in [WIKI_SCHEMA.md](WIKI_SCHEMA.md); added bundle-shape summary to [README.md](README.md).
 - 2026-06-10: updated — [reports/07-pipeline-input-size-study-2026-05.md](reports/07-pipeline-input-size-study-2026-05.md): added GitHub Project backlog table (backend epic [#260](https://github.com/synthet/image-scoring-backend/issues/260), phases [#261–266](https://github.com/synthet/image-scoring-backend/issues/261), gallery [#138](https://github.com/synthet/image-scoring-gallery/issues/138)); cross-refs in [CANONICAL_SOURCES.md](CANONICAL_SOURCES.md), [reports/README.md](reports/README.md), [06-culling-stack-analytics.md](features/implemented/06-culling-stack-analytics.md).
 - 2026-06-10: created — [features/planned/species-conflict-resolution.md](features/planned/species-conflict-resolution.md): "Single Bird Species per Image (BioCLIP top‑1)" — assign one `species:*` keyword per bird image using the BioCLIP 2 argmax (backend `top_k` 3→1 default + max-confidence backfill); supersedes the earlier multi-layer CLI-agent arbitration design (kept as rejected alternative). Indexed in [features/planned/README.md](features/planned/README.md); bidirectional cross-ref in [technical/EMBEDDING_SPACES.md](technical/EMBEDDING_SPACES.md) (`bioclip_2_image` row). Implementation lands in sibling **image-scoring-backend**.
 - 2026-06-10: ingested — [reports/07-pipeline-input-size-study-2026-05.md](reports/07-pipeline-input-size-study-2026-05.md): gallery cross-reference to backend pipeline input-size study (thumbnails, stacks, keywords); indexed in [README.md](README.md), [reports/README.md](reports/README.md); backlinks in [CANONICAL_SOURCES.md](CANONICAL_SOURCES.md), [architecture/01-system-overview.md](architecture/01-system-overview.md), [features/implemented/06-culling-stack-analytics.md](features/implemented/06-culling-stack-analytics.md).

--- a/docs/planning/00-backlog-workflow.md
+++ b/docs/planning/00-backlog-workflow.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Backlog workflow (redirect)"
+description: "Canonical in this repo: docs/project/00-backlog-workflow.md. BACKLOGGOVERNANCE.md is a short alias to that file."
+resource: "docs/planning/00-backlog-workflow.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Backlog workflow (redirect)
 
 **Canonical in this repo:** **[`docs/project/00-backlog-workflow.md`](../project/00-backlog-workflow.md)**. [`BACKLOG_GOVERNANCE.md`](../project/BACKLOG_GOVERNANCE.md) is a short alias to that file.

--- a/docs/planning/01-roadmap-todo.md
+++ b/docs/planning/01-roadmap-todo.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Roadmap TODO — Driftara Gallery (retired)"
+description: "The canonical task queue is the GitHub Project board:"
+resource: "docs/planning/01-roadmap-todo.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Roadmap TODO — Driftara Gallery (retired)
 
 The canonical task queue is the **GitHub Project board**:

--- a/docs/planning/02-firebird-postgresql-migration.md
+++ b/docs/planning/02-firebird-postgresql-migration.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Refined Cross-Repo Migration Plan: Firebird -> PostgreSQL + pgvector"
+description: "Date: 2026-03-08 (plan created), 2026-03-30 (all phases completed)"
+resource: "docs/planning/02-firebird-postgresql-migration.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Refined Cross-Repo Migration Plan: Firebird -> PostgreSQL + pgvector
 
 Date: 2026-03-08 (plan created), 2026-03-30 (all phases completed)

--- a/docs/planning/03-high-impact-tracked-tasks.md
+++ b/docs/planning/03-high-impact-tracked-tasks.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "High-Impact Next Steps - Tracked Tasks"
+description: "Source: TODO.md → Highest-Impact Next Steps (Recommended Sequence)."
+resource: "docs/planning/03-high-impact-tracked-tasks.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # High-Impact Next Steps - Tracked Tasks
 
 Source: `TODO.md` → **Highest-Impact Next Steps (Recommended Sequence)**.

--- a/docs/planning/04-gradio-to-electron-processing-migration.md
+++ b/docs/planning/04-gradio-to-electron-processing-migration.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Gradio → Electron Migration Plan: Processing Workspace"
+description: "Last Updated: Mar 15, 2026."
+resource: "docs/planning/04-gradio-to-electron-processing-migration.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Gradio → Electron Migration Plan: Processing Workspace
 
 Last Updated: Mar 15, 2026.

--- a/docs/planning/GALLERY_VISUAL_IMPROVEMENTS.md
+++ b/docs/planning/GALLERY_VISUAL_IMPROVEMENTS.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Gallery visual improvements (implementation index)"
+description: "Audit: reports/gallery-visual-review/2026-05-31.md"
+resource: "docs/planning/GALLERY_VISUAL_IMPROVEMENTS.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Gallery visual improvements (implementation index)
 
 **Audit:** [reports/gallery-visual-review/2026-05-31.md](../../reports/gallery-visual-review/2026-05-31.md)  

--- a/docs/planning/README.md
+++ b/docs/planning/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Planning"
+description: "Roadmap, migration plans, and task tracking."
+resource: "docs/planning/README.md"
+tags: ["gallery-docs", "index", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Planning
 
 Roadmap, migration plans, and task tracking.

--- a/docs/planning/db_abstraction_layer.md
+++ b/docs/planning/db_abstraction_layer.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Database Connection Abstraction Layer"
+description: "> Status (2026-04): Implemented in electron/db/provider.ts. Firebird and node-firebird have been removed from the Electron app; production uses PostgresConnector (pg) or ApiConnect"
+resource: "docs/planning/db_abstraction_layer.md"
+tags: ["gallery-docs", "planning"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Database Connection Abstraction Layer
 
 > **Status (2026-04):** Implemented in **`electron/db/provider.ts`**. Firebird and `node-firebird` have been **removed** from the Electron app; production uses **`PostgresConnector`** (`pg`) or **`ApiConnector`** (HTTP SQL to the backend). This note is kept for historical context; see [02-database-design.md](../architecture/02-database-design.md) and [02-firebird-postgresql-migration.md](02-firebird-postgresql-migration.md).

--- a/docs/project/00-backlog-workflow.md
+++ b/docs/project/00-backlog-workflow.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Backlog workflow — claiming work, tracking status, keeping the queue truthful"
+description: "The canonical task queue is the GitHub Project board:"
+resource: "docs/project/00-backlog-workflow.md"
+tags: ["gallery-docs", "project"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Backlog workflow — claiming work, tracking status, keeping the queue truthful
 
 The canonical task queue is the **GitHub Project board**:

--- a/docs/project/BACKLOG_GOVERNANCE.md
+++ b/docs/project/BACKLOG_GOVERNANCE.md
@@ -1,3 +1,12 @@
+---
+type: "Planning"
+title: "Backlog governance (retired alias)"
+description: "The canonical task queue is the GitHub Project board:"
+resource: "docs/project/BACKLOG_GOVERNANCE.md"
+tags: ["gallery-docs", "project"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Backlog governance (retired alias)
 
 The canonical task queue is the **GitHub Project board**:

--- a/docs/project/INDEX.md
+++ b/docs/project/INDEX.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Project planning — index"
+description: "See also: Documentation index"
+resource: "docs/project/INDEX.md"
+tags: ["gallery-docs", "index", "project"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Project planning — index
 
 | Document | Description |

--- a/docs/project/TODO.md
+++ b/docs/project/TODO.md
@@ -1,3 +1,12 @@
+---
+type: "Backlog"
+title: "Project backlog (retired)"
+description: "The canonical task queue is the GitHub Project board:"
+resource: "docs/project/TODO.md"
+tags: ["backlog", "gallery-docs", "project"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Project backlog (retired)
 
 The canonical task queue is the **GitHub Project board**:

--- a/docs/reports/01-code-design-review-2026-03.md
+++ b/docs/reports/01-code-design-review-2026-03.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "Frontend Code & Design Review Report"
+description: "Date: 2026-03-02"
+resource: "docs/reports/01-code-design-review-2026-03.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Frontend Code & Design Review Report
 ## image-scoring-gallery v3.24.1
 

--- a/docs/reports/02-code-review-2026-02.md
+++ b/docs/reports/02-code-review-2026-02.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "Code Review + Design Review (2026-02-09)"
+description: "Reviewed:"
+resource: "docs/reports/02-code-review-2026-02.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Code Review + Design Review (2026-02-09)
 
 ## Scope and Method

--- a/docs/reports/03-eslint-audit-2026-03.md
+++ b/docs/reports/03-eslint-audit-2026-03.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "ESLint Audit Report"
+description: "Date: 2026-03-04"
+resource: "docs/reports/03-eslint-audit-2026-03.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # ESLint Audit Report
 
 **Date:** 2026-03-04  

--- a/docs/reports/04-ux-ui-review-2026-03.md
+++ b/docs/reports/04-ux-ui-review-2026-03.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "UX/UI Review — Driftara Gallery (2026-03)"
+description: "This review covers the primary desktop workflow:"
+resource: "docs/reports/04-ux-ui-review-2026-03.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # UX/UI Review — Driftara Gallery (2026-03)
 
 ## Scope

--- a/docs/reports/05-nef-raw-fallback-incident-2026-04-19.md
+++ b/docs/reports/05-nef-raw-fallback-incident-2026-04-19.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "NEF Extraction Tier-1 Failure Incident (2026-04-19)"
+description: "This note preserves the previous implementation-facing analysis that had been stored in docs/features/implemented/01-nef-raw-fallback.md."
+resource: "docs/reports/05-nef-raw-fallback-incident-2026-04-19.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # NEF Extraction Tier-1 Failure Incident (2026-04-19)
 
 ## Incident Summary

--- a/docs/reports/06-code-review-reveal-in-explorer-2026-05.md
+++ b/docs/reports/06-code-review-reveal-in-explorer-2026-05.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "Code Review — Reveal in Explorer + CullingInsightsPanel removal (2026-05-23)"
+description: "PR #93 (feat/culling-analytics, merged into main as e9893c2)."
+resource: "docs/reports/06-code-review-reveal-in-explorer-2026-05.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Code Review — Reveal in Explorer + CullingInsightsPanel removal (2026-05-23)
 
 ## Scope

--- a/docs/reports/07-pipeline-input-size-study-2026-05.md
+++ b/docs/reports/07-pipeline-input-size-study-2026-05.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "Pipeline input-size study — gallery cross-reference (May 2026)"
+description: "Purpose: Record how the sibling image-scoring-backend pipeline-wide input-size research affects Driftara Gallery display quality, stacks/culling UX, and when gallery code might nee"
+resource: "docs/reports/07-pipeline-input-size-study-2026-05.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Pipeline input-size study — gallery cross-reference (May 2026)
 
 **Purpose:** Record how the sibling **image-scoring-backend** pipeline-wide input-size research affects Driftara Gallery display quality, stacks/culling UX, and when gallery code might need coordinated changes.

--- a/docs/reports/DEAD_CODE_REGISTRY.md
+++ b/docs/reports/DEAD_CODE_REGISTRY.md
@@ -1,3 +1,12 @@
+---
+type: "Report"
+title: "Dead Code Registry (gallery)"
+description: "Chronological record of confirmed orphan/dead code removed from image-scoring-gallery. Backend removals: image-scoring-backend/docs/reports/DEADCODEREGISTRY.md."
+resource: "docs/reports/DEAD_CODE_REGISTRY.md"
+tags: ["gallery-docs", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Dead Code Registry (gallery)
 
 Chronological record of confirmed orphan/dead code removed from **image-scoring-gallery**. Backend removals: [image-scoring-backend/docs/reports/DEAD_CODE_REGISTRY.md](https://github.com/synthet/image-scoring-backend/blob/main/docs/reports/DEAD_CODE_REGISTRY.md).

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,3 +1,12 @@
+---
+type: "Index"
+title: "Reports"
+description: "Code reviews, design audits, and quality assessments."
+resource: "docs/reports/README.md"
+tags: ["gallery-docs", "index", "reports"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Reports
 
 Code reviews, design audits, and quality assessments.

--- a/docs/specs/agent-assisted-cull-review/worklog.md
+++ b/docs/specs/agent-assisted-cull-review/worklog.md
@@ -1,3 +1,12 @@
+---
+type: "Log"
+title: "Agent-assisted cull review — gallery worklog"
+description: "Gallery/Electron side of the agent-assisted cull review feature. Backend spec & worklog:"
+resource: "docs/specs/agent-assisted-cull-review/worklog.md"
+tags: ["agent-assisted-cull-review", "gallery-docs", "specs"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Agent-assisted cull review — gallery worklog
 
 Gallery/Electron side of the agent-assisted cull review feature. Backend spec & worklog:

--- a/docs/technical/AGENT_COORDINATION.md
+++ b/docs/technical/AGENT_COORDINATION.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "Agent Coordination (stub)"
+description: "Cross-project integration rules for image-scoring-gallery ↔ image-scoring-backend are maintained in a single canonical document in the backend repo:"
+resource: "docs/technical/AGENT_COORDINATION.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Agent Coordination (stub)
 
 Cross-project integration rules for **image-scoring-gallery** ↔ **image-scoring-backend** are maintained in a **single canonical document** in the backend repo:

--- a/docs/technical/DATABASE_REFACTOR_ANALYSIS.md
+++ b/docs/technical/DATABASE_REFACTOR_ANALYSIS.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "Database Refactor Compatibility Analysis"
+description: "This document analyzes the impact of the proposed DBVECTORSREFACTOR.md on the image-scoring-gallery (Electron) application."
+resource: "docs/technical/DATABASE_REFACTOR_ANALYSIS.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Database Refactor Compatibility Analysis
 
 ## Overview

--- a/docs/technical/EMBEDDING_SPACES.md
+++ b/docs/technical/EMBEDDING_SPACES.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "Embedding spaces (gallery reference)"
+description: "Gallery-facing map of which backend embedding spaces exist, which the desktop app reads today, and which are backend-only opt-in towers — so agents do not assume DINOv2, SigLIP2, o"
+resource: "docs/technical/EMBEDDING_SPACES.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Embedding spaces (gallery reference)
 
 Gallery-facing map of **which backend embedding spaces exist**, **which the desktop app reads today**, and **which are backend-only opt-in towers** — so agents do not assume DINOv2, SigLIP2, or OpenAI CLIP L/14 are in the production path.

--- a/docs/technical/EXTERNAL_CLI_REVIEWS.md
+++ b/docs/technical/EXTERNAL_CLI_REVIEWS.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "External CLI reviews (subagent-orchestrator)"
+description: "Optional review-only second opinions from Codex or Gemini CLI for this gallery workspace."
+resource: "docs/technical/EXTERNAL_CLI_REVIEWS.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # External CLI reviews (subagent-orchestrator)
 
 Optional **review-only** second opinions from **Codex** or **Gemini CLI** for this gallery workspace.

--- a/docs/technical/OPENAPI_CONTRACT.md
+++ b/docs/technical/OPENAPI_CONTRACT.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "OpenAPI Contract (Gallery Consumer)"
+description: "Driftara Gallery does not define its own REST OpenAPI spec. The canonical contract is owned by image-scoring-backend:"
+resource: "docs/technical/OPENAPI_CONTRACT.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # OpenAPI Contract (Gallery Consumer)
 
 Driftara Gallery does **not** define its own REST OpenAPI spec. The canonical contract is owned by **image-scoring-backend**:

--- a/docs/technical/PIPELINE_TERMINOLOGY.md
+++ b/docs/technical/PIPELINE_TERMINOLOGY.md
@@ -1,3 +1,12 @@
+---
+type: "Technical Reference"
+title: "Pipeline terminology (Electron gallery)"
+description: "This app mirrors the canonical stage names defined in image-scoring-backend so labels match the Gradio Pipeline tab and the backend Vite SPA (/ui/)."
+resource: "docs/technical/PIPELINE_TERMINOLOGY.md"
+tags: ["gallery-docs", "technical"]
+timestamp: 2026-06-16T00:00:00Z
+---
+
 # Pipeline terminology (Electron gallery)
 
 This app mirrors the **canonical stage names** defined in **image-scoring-backend** so labels match the Gradio Pipeline tab and the backend Vite SPA (`/ui/`).


### PR DESCRIPTION
### Motivation

- Make the repository docs machine-friendly and discoverable by adopting an Open Knowledge Format (OKF)-style bundle so agents and search tools can treat each Markdown page as a first-class concept. 
- Provide a stable concept identity via repository-relative `resource` paths and lightweight metadata so indexes, navigation pages, and automation can reliably reference docs. 

### Description

- Added required OKF YAML frontmatter (`type`, `title`, `description`, `resource`, `tags`, `timestamp`) to every `docs/**/*.md` concept page (69 files). 
- Documented the OKF contract and maintenance workflow in `docs/WIKI_SCHEMA.md` and added an OKF bundle overview to `docs/README.md`. 
- Updated `docs/log.md` to record the reorganization and added index/frontmatter metadata to relevant section `README.md`/`INDEX.md` files. 
- Ensured `resource` values mirror file paths and that `tags` are provided for queryability across the docs tree. 

### Testing

- Attempted a PyYAML-based validation but the environment lacked the `yaml` module, so that run could not complete. 
- Ran a dependency-free Python check that parsed frontmatter text, verified presence of the required fields, confirmed `resource` matches each file path, and validated inline `tags` format across all 69 `docs/**/*.md` files, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30cc646b108323b35bfe508b31234a)