### PR TITLE
Apply agentic-framework improvements: tests-first, /eval, /decompose

### DIFF
--- a/.agent/SKILL_INVENTORY.md
+++ b/.agent/SKILL_INVENTORY.md
@@ -21,6 +21,7 @@ Central list of **first-party** `SKILL.md` files in **image-scoring-gallery** fo
 | changelog-commit-push | `.cursor/skills/changelog-commit-push/SKILL.md` | CHANGELOG, commit, push | L2 | — | 2026-04-25 |
 | commit-conventions | `.cursor/skills/commit-conventions/SKILL.md` | Conventional Commits / PR titles | L1 | — | 2026-04-25 |
 | docs-wiki | `.cursor/skills/docs-wiki/SKILL.md` | OKF-style `docs/` wiki conventions | L1 | — | 2026-06-16 |
+| eval | `.cursor/skills/eval/SKILL.md` | Capture task quality signals (test_pass_rate / first_try_success / iteration_count) → agent-memory feedback loop | L1 | Yes | 2026-06-19 |
 | gallery-electron-ts | `.cursor/skills/gallery-electron-ts/SKILL.md` | Electron / TS / db contract | L1 | — | 2026-04-25 |
 | security-review | `.cursor/skills/security-review/SKILL.md` | Pre-merge security sanity | L1 | — | 2026-04-25 |
 | subagent-review | `.cursor/skills/subagent-review/SKILL.md` | External Codex/Gemini review via subagent-orchestrator MCP | L2 | Yes | 2026-05-26 |

--- a/.claude/commands/decompose.md
+++ b/.claude/commands/decompose.md
@@ -1,0 +1,42 @@
+> **Claude Code:** Same intent as Cursor `/decompose`. When customizing, keep in sync with `.cursor/commands/decompose.md`.
+
+# /decompose — Break a task into parallelizable subtasks
+
+Use after a `/spec` exists (or for a sizable task) and **before** `/plan`. The goal is
+to split work into independent units a fleet of agents can execute on separate
+branches simultaneously — humans orchestrate, agents execute.
+
+## Inputs
+
+- Approved spec or a tight task description.
+- Constraints and tech stack (see **AGENTS.md**).
+
+## Output
+
+1. **Subtask list** — For each subtask:
+   - **Title**
+   - **Done means** — one-liner describing the verifiable end state.
+   - **Size** — `S` / `M` / `L`.
+   - **Dependencies** — which other subtasks (if any) must land first.
+
+2. **Dependency graph** — Show ordering and call out which subtasks are **independent**
+   (no shared edits, no ordering constraint) and can run in parallel. A simple
+   list/edge form is fine, e.g. `A → C`, `B → C`, `A ∥ B`.
+
+3. **Parallel execution note** — State it explicitly, e.g.:
+   > "Subtasks X, Y, Z are independent. Run as separate branches simultaneously using
+   > git worktrees or separate sessions."
+
+4. **Test boundaries** — For each subtask, how it validates **independently**: which
+   failing test stubs / assertions prove it done on its own branch without the others.
+
+## Done when
+
+- Each subtask can be `/plan`-ed independently with no hidden dependencies.
+- Every subtask has a one-line "done means" and an independent test boundary.
+- Independent subtasks are clearly marked as parallel-safe.
+
+## Note
+
+If the user has not approved implementation, **do not** apply code changes — this
+command only produces the decomposition.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -11,18 +11,22 @@ Use when the user has approved a plan or given a small, explicit task.
 
 ## Steps
 
-1. Implement in **minimal diffs**; match existing style.
-2. Add or update tests when behavior changes.
+1. **Write failing test stubs from the plan, confirm they fail** — encode each acceptance criterion as a test before touching implementation; run them and verify they fail for the right reason.
+2. **Implement until stubs pass** — in **minimal diffs**, matching existing style; never assume generated code works until it has been executed.
 3. Run **lint** and **tests** from AGENTS.md; fix failures.
 4. Summarize what changed and where.
 
 ## Done when
 
+- Test stubs written and failing before implementation began.
 - All agreed items are implemented.
+- Tests pass after implementation.
 - Lint and tests pass (or failures are explained with next steps).
 
 ## Checklist
 
+- [ ] Test stubs written and failing before implementation began
+- [ ] Tests pass after implementation
 - [ ] No unrelated refactors
 - [ ] No secrets committed
 - [ ] AGENTS.md commands run (or documented why not)

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -14,12 +14,13 @@ Use after a spec exists (or for small tasks, a verbal agreement). Prefer **plan 
 1. **Goal** — What “done” means.
 2. **Files / areas to touch** — Paths or components.
 3. **Approach** — Steps in order; call out risky changes.
-4. **Tests** — What to run or add (map to AGENTS.md commands).
+4. **Failing test stubs to write BEFORE touching implementation** — Name the specific tests/assertions (mapped from spec acceptance criteria) that should be authored and confirmed failing first; map them to AGENTS.md commands.
 5. **Rollback / flags** — If feature-flagged or migratory.
 
 ## Done when
 
 - Another developer could execute the plan without guessing.
+- Failing test stubs identified and ready to write before implementation begins.
 - Test plan matches project conventions.
 
 ## Note

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -15,12 +15,12 @@ Use when starting non-trivial work. Produce a **spec** the team can review befor
 2. **Users / stakeholders** — Who benefits.
 3. **Non-goals** — What is explicitly out of scope.
 4. **User stories** — Short “As a … I want … so that …” bullets.
-5. **Acceptance criteria** — Checkable bullets (Given/When/Then or “When X, then Y”).
+5. **Acceptance criteria** — Each criterion **must** be written in **Given/When/Then** or **“When X → assert Y”** form so it maps 1:1 to a test assertion. No prose-only criteria.
 6. **Open questions** — Unknowns and decisions needed from humans.
 
 ## Done when
 
-- Criteria are testable without interpreting intent.
+- Every criterion is directly translatable to a runnable test assertion without interpretation.
 - Non-goals prevent scope creep.
 
 ## Optional

--- a/.claude/skills/eval/SKILL.md
+++ b/.claude/skills/eval/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: eval
+description: Capture task quality signals and log them to agent memory to build a
+  feedback loop. Use at the end of each implemented task or merged PR.
+---
+
+> **Claude Code mirror.** Canonical: [`.cursor/skills/eval/SKILL.md`](../../../.cursor/skills/eval/SKILL.md). Keep both in sync.
+
+# /eval — Feedback-loop capture
+
+Eval design — building feedback loops with verifiable signals — is a core agentic
+skill. Run this at the **end of each implemented task or merged PR** so that what
+worked (and what didn't) becomes durable, queryable agent memory instead of being
+lost between sessions.
+
+## When to use
+
+- Immediately after `/implement` finishes and tests are green.
+- Right after a PR merges.
+- After abandoning or re-scoping a task (capture the *why*).
+
+## Step 1 — Record the three signals
+
+Collect these verifiable signals for the task you just finished:
+
+| Signal | Values | How to measure |
+|--------|--------|----------------|
+| `test_pass_rate` | `yes` / `partial` / `no` | Did the test suite (or the task's failing stubs) end fully green? `partial` = some still red/skipped. |
+| `first_try_success` | `yes` / `no` | Did the implementation pass its tests on the first run, with no rework cycle? |
+| `iteration_count` | integer (≥ 1) | Number of implement→test→fix cycles before done. |
+
+## Step 2 — Map the outcome to a memory candidate
+
+Use the signals to decide **what** to remember and **how confident** to be:
+
+| Outcome | Memory candidate type | Confidence |
+|---------|----------------------|------------|
+| First-try success, all tests green | `successful_pattern` | `high` |
+| More than 2 iterations to finish | `recurring_issue` | `medium` |
+| Tests were missing (no stubs existed before implementation) | `working_rule` | `high` |
+
+Write the candidate as a concise, factual statement (active voice), e.g.:
+- `successful_pattern`: "IPC handlers in `electron/main.ts` are fastest to land when the
+  failing stub is written in `electron/__tests__` first."
+- `recurring_issue`: "`database.engine: api` changes repeatedly break because the SQL
+  shape isn't validated against the backend contract before coding."
+- `working_rule`: "Always author a failing test stub for new `db.ts` query helpers
+  before implementing — tasks that skipped this needed 3+ iterations."
+
+## Step 3 — Log the candidate to agent memory
+
+Persist the candidate so future sessions can retrieve it. Example logging call:
+
+```bash
+/log-session --candidate \
+  --type successful_pattern \
+  --confidence high \
+  --signals "test_pass_rate=yes,first_try_success=yes,iteration_count=1" \
+  --note "IPC handler tasks land first-try when the failing stub is written first."
+```
+
+In this repo the durable store is the **Memory MCP knowledge graph** (see the
+`memory-mcp` skill). If `/log-session` is not wired up, equivalently call the Memory
+MCP directly: `search_nodes` first to avoid duplicates, then `add_observations`
+(existing entity) or `create_entities` (new), tagging the candidate `type` and
+`confidence` and including the three signals as observations.
+
+## Done when
+
+- The three signals are recorded for the task.
+- A memory candidate (type + confidence) has been written to agent memory, or you
+  explicitly noted that no candidate was warranted.
+
+## See also
+
+- `memory-mcp` skill — the durable agent-memory store this feedback loop writes to.
+- `/log-session` — session/candidate logging entry point (when configured).
+- `/implement` — tests-first execution that produces the signals captured here.

--- a/.cursor/commands/decompose.md
+++ b/.cursor/commands/decompose.md
@@ -1,0 +1,40 @@
+# /decompose — Break a task into parallelizable subtasks
+
+Use after a `/spec` exists (or for a sizable task) and **before** `/plan`. The goal is
+to split work into independent units a fleet of agents can execute on separate
+branches simultaneously — humans orchestrate, agents execute.
+
+## Inputs
+
+- Approved spec or a tight task description.
+- Constraints and tech stack (see **AGENTS.md**).
+
+## Output
+
+1. **Subtask list** — For each subtask:
+   - **Title**
+   - **Done means** — one-liner describing the verifiable end state.
+   - **Size** — `S` / `M` / `L`.
+   - **Dependencies** — which other subtasks (if any) must land first.
+
+2. **Dependency graph** — Show ordering and call out which subtasks are **independent**
+   (no shared edits, no ordering constraint) and can run in parallel. A simple
+   list/edge form is fine, e.g. `A → C`, `B → C`, `A ∥ B`.
+
+3. **Parallel execution note** — State it explicitly, e.g.:
+   > "Subtasks X, Y, Z are independent. Run as separate branches simultaneously using
+   > git worktrees or separate sessions."
+
+4. **Test boundaries** — For each subtask, how it validates **independently**: which
+   failing test stubs / assertions prove it done on its own branch without the others.
+
+## Done when
+
+- Each subtask can be `/plan`-ed independently with no hidden dependencies.
+- Every subtask has a one-line "done means" and an independent test boundary.
+- Independent subtasks are clearly marked as parallel-safe.
+
+## Note
+
+If the user has not approved implementation, **do not** apply code changes — this
+command only produces the decomposition.

--- a/.cursor/commands/implement.md
+++ b/.cursor/commands/implement.md
@@ -9,18 +9,22 @@ Use when the user has approved a plan or given a small, explicit task.
 
 ## Steps
 
-1. Implement in **minimal diffs**; match existing style.
-2. Add or update tests when behavior changes.
+1. **Write failing test stubs from the plan, confirm they fail** — encode each acceptance criterion as a test before touching implementation; run them and verify they fail for the right reason.
+2. **Implement until stubs pass** — in **minimal diffs**, matching existing style; never assume generated code works until it has been executed.
 3. Run **lint** and **tests** from AGENTS.md; fix failures.
 4. Summarize what changed and where.
 
 ## Done when
 
+- Test stubs written and failing before implementation began.
 - All agreed items are implemented.
+- Tests pass after implementation.
 - Lint and tests pass (or failures are explained with next steps).
 
 ## Checklist
 
+- [ ] Test stubs written and failing before implementation began
+- [ ] Tests pass after implementation
 - [ ] No unrelated refactors
 - [ ] No secrets committed
 - [ ] AGENTS.md commands run (or documented why not)

--- a/.cursor/commands/plan.md
+++ b/.cursor/commands/plan.md
@@ -12,12 +12,13 @@ Use after a spec exists (or for small tasks, a verbal agreement). Prefer **plan 
 1. **Goal** — What “done” means.
 2. **Files / areas to touch** — Paths or components.
 3. **Approach** — Steps in order; call out risky changes.
-4. **Tests** — What to run or add (map to AGENTS.md commands).
+4. **Failing test stubs to write BEFORE touching implementation** — Name the specific tests/assertions (mapped from spec acceptance criteria) that should be authored and confirmed failing first; map them to AGENTS.md commands.
 5. **Rollback / flags** — If feature-flagged or migratory.
 
 ## Done when
 
 - Another developer could execute the plan without guessing.
+- Failing test stubs identified and ready to write before implementation begins.
 - Test plan matches project conventions.
 
 ## Note

--- a/.cursor/commands/spec.md
+++ b/.cursor/commands/spec.md
@@ -13,12 +13,12 @@ Use when starting non-trivial work. Produce a **spec** the team can review befor
 2. **Users / stakeholders** — Who benefits.
 3. **Non-goals** — What is explicitly out of scope.
 4. **User stories** — Short “As a … I want … so that …” bullets.
-5. **Acceptance criteria** — Checkable bullets (Given/When/Then or “When X, then Y”).
+5. **Acceptance criteria** — Each criterion **must** be written in **Given/When/Then** or **“When X → assert Y”** form so it maps 1:1 to a test assertion. No prose-only criteria.
 6. **Open questions** — Unknowns and decisions needed from humans.
 
 ## Done when
 
-- Criteria are testable without interpreting intent.
+- Every criterion is directly translatable to a runnable test assertion without interpretation.
 - Non-goals prevent scope creep.
 
 ## Optional

--- a/.cursor/rules/implementation.mdc
+++ b/.cursor/rules/implementation.mdc
@@ -18,5 +18,5 @@ alwaysApply: false
 
 ## Quality bar
 
-- Add or update tests when behavior changes in non-trivial ways (follow project conventions in AGENTS.md).
+- **Tests-first:** write failing test stubs from the plan/spec acceptance criteria and confirm they fail *before* implementing, then implement until they pass (see `/implement`). Never assume generated code works until it has been executed.
 - Handle errors in a way consistent with surrounding code (no silent swallowing unless intentional).

--- a/.cursor/skills/eval/SKILL.md
+++ b/.cursor/skills/eval/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: eval
+description: Capture task quality signals and log them to agent memory to build a
+  feedback loop. Use at the end of each implemented task or merged PR.
+---
+
+# /eval — Feedback-loop capture
+
+Eval design — building feedback loops with verifiable signals — is a core agentic
+skill. Run this at the **end of each implemented task or merged PR** so that what
+worked (and what didn't) becomes durable, queryable agent memory instead of being
+lost between sessions.
+
+## When to use
+
+- Immediately after `/implement` finishes and tests are green.
+- Right after a PR merges.
+- After abandoning or re-scoping a task (capture the *why*).
+
+## Step 1 — Record the three signals
+
+Collect these verifiable signals for the task you just finished:
+
+| Signal | Values | How to measure |
+|--------|--------|----------------|
+| `test_pass_rate` | `yes` / `partial` / `no` | Did the test suite (or the task's failing stubs) end fully green? `partial` = some still red/skipped. |
+| `first_try_success` | `yes` / `no` | Did the implementation pass its tests on the first run, with no rework cycle? |
+| `iteration_count` | integer (≥ 1) | Number of implement→test→fix cycles before done. |
+
+## Step 2 — Map the outcome to a memory candidate
+
+Use the signals to decide **what** to remember and **how confident** to be:
+
+| Outcome | Memory candidate type | Confidence |
+|---------|----------------------|------------|
+| First-try success, all tests green | `successful_pattern` | `high` |
+| More than 2 iterations to finish | `recurring_issue` | `medium` |
+| Tests were missing (no stubs existed before implementation) | `working_rule` | `high` |
+
+Write the candidate as a concise, factual statement (active voice), e.g.:
+- `successful_pattern`: "IPC handlers in `electron/main.ts` are fastest to land when the
+  failing stub is written in `electron/__tests__` first."
+- `recurring_issue`: "`database.engine: api` changes repeatedly break because the SQL
+  shape isn't validated against the backend contract before coding."
+- `working_rule`: "Always author a failing test stub for new `db.ts` query helpers
+  before implementing — tasks that skipped this needed 3+ iterations."
+
+## Step 3 — Log the candidate to agent memory
+
+Persist the candidate so future sessions can retrieve it. Example logging call:
+
+```bash
+/log-session --candidate \
+  --type successful_pattern \
+  --confidence high \
+  --signals "test_pass_rate=yes,first_try_success=yes,iteration_count=1" \
+  --note "IPC handler tasks land first-try when the failing stub is written first."
+```
+
+In this repo the durable store is the **Memory MCP knowledge graph** (see the
+`memory-mcp` skill). If `/log-session` is not wired up, equivalently call the Memory
+MCP directly: `search_nodes` first to avoid duplicates, then `add_observations`
+(existing entity) or `create_entities` (new), tagging the candidate `type` and
+`confidence` and including the three signals as observations.
+
+## Done when
+
+- The three signals are recorded for the task.
+- A memory candidate (type + confidence) has been written to agent memory, or you
+  explicitly noted that no candidate was warranted.
+
+## See also
+
+- `memory-mcp` skill — the durable agent-memory store this feedback loop writes to.
+- `/log-session` — session/candidate logging entry point (when configured).
+- `/implement` — tests-first execution that produces the signals captured here.

--- a/.github/workflows/test-and-contract.yml
+++ b/.github/workflows/test-and-contract.yml
@@ -72,7 +72,12 @@ jobs:
           --fail-on error
 
       - name: Fetch backend OpenAPI snapshot source
-        run: git clone --depth 1 https://github.com/synthet/image-scoring-backend ../image-scoring-backend
+        # Reuses the clone from "Fetch backend OKF linter" above; clone only if absent
+        # (cloning into the existing path fails with exit 128).
+        run: |
+          if [ ! -d ../image-scoring-backend/.git ]; then
+            git clone --depth 1 https://github.com/synthet/image-scoring-backend ../image-scoring-backend
+          fi
 
       # Canonical gate: contract:check fails when generated contract files drift from source API types.
       # This blocks merges until contract artifacts are updated and committed.


### PR DESCRIPTION
Implements the applicable expert findings (Karpathy spec-first/eval,
Willison tests-first, Weng memory feedback, Anthropic context files,
OWASP governance):

1. Tests-first enforcement across /spec, /plan, /implement (both .cursor
   canonical and .claude mirrors), plus implementation.mdc quality bar:
   - /spec: acceptance criteria must be Given/When/Then or "When X -> assert Y";
     Done when each criterion maps 1:1 to a runnable test assertion.
   - /plan: Tests section renamed to "Failing test stubs to write BEFORE
     touching implementation"; Done when stubs are identified.
   - /implement: step 1 writes failing stubs and confirms they fail, step 2
     implements until stubs pass; Done when + Checklist require both.

2. New /eval feedback-loop skill (.cursor + .claude) capturing
   test_pass_rate / first_try_success / iteration_count, outcome->memory
   candidate mapping, and a /log-session --candidate example; registered in
   SKILL_INVENTORY (OWASP AST09 governance).

3. New /decompose command (.cursor + .claude): subtask list, dependency
   graph, parallel-execution note, and independent test boundaries.

Improvements 4 (memory staleness pipeline) and 5 (bootstrap auto-detection)
are N/A: this repo has no .agent-memory pipeline or bootstrap.py.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01REbEiA3joRedUMZ5XvuvuC